### PR TITLE
[20240921] CDT/보통/외판원 순회/김득호

### DIFF
--- a/202409/18 CDT 외판원순회.md
+++ b/202409/18 CDT 외판원순회.md
@@ -1,0 +1,74 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static int N;
+    public static int[][] grid;
+    public static boolean[] visited;
+    public static int minCost = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        grid = new int[N][N];
+
+        visited = new boolean[N];
+
+        for(int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < N; j++) {
+                grid[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        simulate();
+    }
+
+    //모든 경우의 수 순회하기
+    public static void simulate() {
+        for (int i = 1; i < N; i++) {
+            int currentCost = 0;
+            if(canGo(0,i)) {
+                visited[i] = true;
+                currentCost += grid[0][i];
+                dfs(i, currentCost, 1);
+                visited[i] = false;
+            }
+        }
+        
+        System.out.println(minCost);
+    }
+
+    public static void dfs(int row, int currentCost, int depth) {
+
+        if (depth == N - 1) {
+            currentCost += grid[row][0];
+            minCost = Math.min(currentCost, minCost);
+            return;
+        }
+
+        for(int i = 1; i < N; i++) {
+            if(canGo(row,i)) {
+                visited[i] = true;
+                currentCost += grid[row][i];
+                dfs(i, currentCost, depth+1);
+                currentCost -= grid[row][i];
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static boolean canGo(int row, int col) {
+        if(row == col) return false;
+        if(grid[row][col] == 0) return false;
+        if(visited[col]) return false;
+        return true;
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.codetree.ai/missions/2/problems/traveling-salesman-problem/description
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
각 정점을 모두 방문하면서 최소 비용의 합을 구하는 문제
(중복된 정점을 방문할 수 없다.)

## 🔍 풀이 방법
백트래킹을 사용하여 완전탐색

## ⏳ 회고
오랜만에 문제풀이를 해서 더 빠르게 구현할 수 있도록 
연습이 필요함.
