### PR TITLE
[20240926] BAJ / 골드4 / 숨바꼭질 4 / 강경민

### DIFF
--- a/Kang/202409/26 BAJ 숨바꼭질 4.md
+++ b/Kang/202409/26 BAJ 숨바꼭질 4.md
@@ -1,0 +1,38 @@
+```python
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N, K = map(int ,input().rstrip().split())
+visit = [True for _ in range(100000 + 1)]
+visit[N] = False
+queue = deque([(N, 0, [N])])
+
+
+while queue:
+    n, c, load = queue.popleft()
+    if n == K:
+        print(c)
+        print(*load)
+        break
+
+    if n + 1 < K + 1\
+    and visit[n + 1]: 
+        a_load = load.copy()
+        visit[n + 1] = False
+        a_load.append(n + 1)
+        queue.append((n + 1, c + 1, a_load))
+    if 0 <= n - 1\
+    and visit[n - 1]:
+        b_load = load.copy()
+        visit[n - 1] = False
+        b_load.append(n - 1)
+        queue.append((n - 1, c + 1, b_load))
+    if n * 2 < K + 1\
+    and visit[2 * n]:
+        c_load = load.copy()
+        visit[2 * n] = False
+        c_load.append(2 * n)
+        queue.append((2 * n, c + 1, c_load))
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13913
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
bfs로 최단 거리를 찾는 문제인데
지나온 경로를 체크해줘야하는 문제이다.
## 🔍 풀이 방법
지나온 경로를 노드별로 갖고 있게 했더니 메모리 초과가 나서
방문한 노드는 방문하지 않게 했더니 틀렸다
>풀이
>- dp배열에 지나온 경로에 이전 부모 노드를 기록해 놓으면 되는 문제였다.
## ⏳ 회고
항상 이 경로 체크 문제가 나오면 바보처럼 풀지를 못하는데 이런 문제 더 풀어야 한다ㅠ