### PR TITLE
[20240927] BAJ / 골드3 / 수 묶기 / 김민중

### DIFF
--- a/kmj-99/202409/27 수 묶기.md
+++ b/kmj-99/202409/27 수 묶기.md
@@ -1,0 +1,72 @@
+package com.prototype.codingtest
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+fun main(){
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+    val n = br.readLine().toInt()
+
+    val leftSequenceList=ArrayList<Int>()
+    val rightSequenceList=ArrayList<Int>()
+
+    repeat(n){
+        var input=br.readLine().toInt()
+        if(input<=0){
+            leftSequenceList.add(input)
+        }else{
+            rightSequenceList.add(input)
+        }
+    }
+
+    leftSequenceList.sort()
+    rightSequenceList.sortByDescending { it }
+
+    var index=-1
+    var res:Long=0L
+    for(i in 0 until leftSequenceList.size){
+        if(i==index){
+            continue
+        }
+
+        if(i+1==leftSequenceList.size){
+            res+=leftSequenceList[i]
+            break
+        }
+
+
+        index=i+1
+        res+=(leftSequenceList[i]*leftSequenceList[i+1])
+    }
+
+
+    index=-1
+
+    for(i in 0 until rightSequenceList.size){
+        if(i==index){
+            continue
+        }
+
+        if(i+1==rightSequenceList.size){
+            res+=rightSequenceList[i]
+            break
+        }
+
+
+        index=i+1
+        if(rightSequenceList[i]==1 || rightSequenceList[i+1]==1){
+            res+=(rightSequenceList[i]+rightSequenceList[i+1])
+        }else{
+            res+=(rightSequenceList[i]*rightSequenceList[i+1])
+        }
+    }
+
+    bw.write(res.toString())
+    bw.flush()
+    bw.close()
+
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1744
## 🧭 풀이 시간
40분
## 👀 체감 난이도
- [] 상
- [x] 중
- [] 하
## ✏️ 문제 설명
수열에 있는 2개의 수를 임의로 묶어서 수열의 합을 최대로 만들어야한다.
## 🔍 풀이 방법
음수와 양수로 나누고 각각 내림차순, 오름차순 정렬을 하여 두 개의 수를 묶어서 더해주는 식으로 풀이
## ⏳ 회고
양수와 음수로 나누고 각각 최적의 해를 찾는다는 점에서 그리디의 느낌을 잘 느낄 수 있었다.
