### PR TITLE
[20241008] BAJ / 골드4/줄세우기/김득호

### DIFF
--- a/Ho/202410/8 BAJ 줄세우기.md
+++ b/Ho/202410/8 BAJ 줄세우기.md
@@ -1,0 +1,51 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class P2631 {
+
+    static int N;
+    static int ans = 0;
+    static int[] arr;
+    static int[] dp;
+    static int max;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        arr = new int[N];
+        dp = new int[N];
+        
+
+        for(int i = 0; i < N; i++) {
+            int num = Integer.parseInt(br.readLine());
+            arr[i] = num;
+        }
+
+        max = 0;
+        Arrays.fill(dp, 1);
+
+        for(int i = N-2; i >= 0; i--) {
+            int curNum = arr[i];
+            int tempMax = 1;
+
+            for(int j = i+1; j < N; j++) {
+                if(curNum < arr[j]) {
+                    tempMax = Math.max(tempMax, dp[i] + dp[j]);
+                }
+            }
+            dp[i] = tempMax;
+
+            max = Math.max(max, dp[i]);
+        }
+
+        System.out.print(N - max);
+
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
## 🧭 풀이 시간
90분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
LIS를 활용한 문제
## 🔍 풀이 방법
LIS를 사용해서 최장 수열 길이를 구하고 전체길이에서 빼준다.
## ⏳ 회고
많이 연습해서 구현속도를 높여야한다.
