### PR TITLE
[20241010]/프로그래머스/레벨2/두큐합같게만들기

### DIFF
--- a/kmj-99/202410/10 두큐합같게만들기.md
+++ b/kmj-99/202410/10 두큐합같게만들기.md
@@ -1,0 +1,32 @@
+class Solution {
+    fun solution(queue1: IntArray, queue2: IntArray): Int {
+        var count = 0
+        val que1 = ArrayDeque(queue1.toList())
+        val que2 = ArrayDeque(queue2.toList())
+        var sum1 = queue1.sumOf { it.toLong() }
+        var sum2 = queue2.sumOf { it.toLong() }
+        
+        val maxOperations = (queue1.size + queue2.size) * 2
+        
+        while (count <= maxOperations) {
+            when {
+                sum1 < sum2 -> {
+                    val temp = que2.removeFirst()
+                    que1.addLast(temp)
+                    sum1 += temp
+                    sum2 -= temp
+                }
+                sum1 > sum2 -> {
+                    val temp = que1.removeFirst()
+                    que2.addLast(temp)
+                    sum1 -= temp
+                    sum2 += temp
+                }
+                else -> return count
+            }
+            count++
+        }
+        
+        return -1
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/118667
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
두 개의 큐가 주어졌을 때 각 큐의 합이 서로 같도록 하는 최소의 pop,push 연산 수를 구하는 문제
## 🔍 풀이 방법
최대 연산 횟수는 두 개의 큐의 사이즈 합이기 때문에, 연산을 다 돌면서 합이 큰 값에서 합이 작은 값으로 원소를 옮겨서 합을 맞추는 식으로 접근
## ⏳ 회고
SoSo했다.
