### PR TITLE
[20241014] BAJ / 골드4 / 이차원 배열과 연산 / 양진혁

### DIFF
--- a/JinHyeok/202410/14 BAJ 이차원 배열과 연산.md
+++ b/JinHyeok/202410/14 BAJ 이차원 배열과 연산.md
@@ -1,0 +1,115 @@
+```
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <utility>
+using namespace std;
+
+int board[101][101];
+int freq[101];
+int row = 3, col = 3, sec = 0;
+
+bool cmp(pair<int, int> n1, pair<int, int> n2) {
+    if (n1.second == n2.second) {
+        return n1.first < n2.first;
+    }
+    else {
+        return n1.second < n2.second;
+    }
+}
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+
+    int r, c, k;
+    cin >> r >> c >> k;
+
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            cin >> board[i][j];
+        }
+    }
+
+    while (true) {
+        if (board[r - 1][c - 1] == k) {
+            break;
+        }
+        if (sec == 100) {
+            sec = -1;
+            break;
+        }
+
+        int first, second;
+        if (row >= col) {
+            first = row;
+            second = col;
+        }
+        else {
+            first = col;
+            second = row;
+        }
+
+        vector<int> l(first);
+        for (int i = 0; i < first; i++) {
+            fill(freq, freq + 101, 0);
+            vector<pair<int, int>> sf;
+
+            for (int j = 0; j < second; j++) {
+                if (row >= col) {
+                    freq[board[i][j]]++;
+                }
+                else {
+                    freq[board[j][i]]++;
+                }
+            }
+
+            for (int j = 1; j <= 100; j++) {
+                if (freq[j] != 0) {
+                    sf.push_back({ j, freq[j] });
+                }
+            }
+
+            sort(sf.begin(), sf.end(), cmp);
+
+            for (int j = 0; j < sf.size() && j < 50; j++) {
+                if (row >= col) {
+                    board[i][j * 2] = sf[j].first;
+                    board[i][j * 2 + 1] = sf[j].second;
+                }
+                else {
+                    board[j * 2][i] = sf[j].first;
+                    board[j * 2 + 1][i] = sf[j].second;
+                }
+            }
+
+            l[i] = (sf.size() >= 50) ? 100 : sf.size() * 2;
+        }
+
+        second = *max_element(l.begin(), l.end());
+
+        for (int i = 0; i < first; i++) {
+            for (int j = l[i]; j < second; j++) {
+                if (row >= col) {
+                    board[i][j] = 0;
+                }
+                else {
+                    board[j][i] = 0;
+                }
+            }
+        }
+
+        if (row >= col) {
+            col = second;
+        }
+        else {
+            row = second;
+        }
+
+        sec++;
+    }
+
+    cout << sec;
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17140
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
R,C,K와 배열을 주고 
배열의 [R][C]가 K가 되기 위한 연산의 최소시간 구하기
## 🔍 풀이 방법
(
board는 2차원 배열, freq는 빈도수 배열이며, R 연산이 기준)

1. 현재 행(i)을 확인한다. 
     i행의 각 열(j)을 확인하고, freq[board[i][j]]를 증가시킨다.
     빈도수 배열을 순회하며 {빈도수 배열의 인덱스, 해당 인덱스의 빈도수}를 벡터에 넣는다.
     벡터를 정렬 기준에 따라 정렬한다. (수의 등장 횟수가 커지는 순, 그러한 것이 여러가지면 수가 커지는 순으로 정렬)
      정렬된 벡터를 다시 board에 기록한다.
2. (i + 1) 행을 확인한다. (단, 마지막 행이라면 3번을 진행한다.)
3. 마지막 행의 크기에 맞춰 나머지 부분을 0으로 채운다.

⚠️ 주의할 점
빈도수 배열의 크기 (숫자 100도 빈도수 배열에 들어갈 수 있어야 함)
행의 크기가 100보다 크다면, 100까지만 기록하고, 행의 크기가 최대 100이 되도록 해주어야 함.
숫자 0, 빈도수가 0인 수는 무시해야 함.

## ⏳ 회고
방법이 떠오르질 않았다.. 구현은 더 열심히해야될듯