### PR TITLE
[202401015] BAJ / 골드3 / 타일채우기 / 김민중

### DIFF
--- a/kmj-99/15 BJ2133.md
+++ b/kmj-99/15 BJ2133.md
@@ -1,0 +1,34 @@
+package com.prototype.codingtest.DP
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+fun main() {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+    val n = br.readLine().toInt()
+    if (n % 2 != 0) {
+        bw.write("0")
+        bw.flush()
+        return
+    }
+
+    val dp = MutableList(n + 1) { 0 }
+
+    // Base cases
+    dp[0] = 1 // 1 way to fill a 3x0 wall (do nothing)
+    dp[2] = 3 // 3 ways to fill a 3x2 wall
+
+    for (i in 4..n step 2) {
+        dp[i] = dp[i - 2] * 3
+        for (j in 4..i step 2) {
+            dp[i] += dp[i - j] * 2
+        }
+    }
+
+    bw.write("${dp[n]}")
+    bw.flush()
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
3*N의 타일을 2*1, 1*2 타일로 채울 수 있는 경우의 수
## 🔍 풀이 방법
N-2, N-4일 때 모양이 계속 반복이 되기 때문에 이걸 이용해서 점화식을 세워서 접근
## ⏳ 회고
점화식만 잘 세우면 쉽게 풀리는 거 같다.
