### PR TITLE
[20241019] BAJ / 실버1 / 점프 / 김민중

### DIFF
--- a/kmj-99/202410/22 1890.md
+++ b/kmj-99/202410/22 1890.md
@@ -1,0 +1,50 @@
+package com.prototype.codingtest.DP
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+fun main(){
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+    val n = br.readLine().toInt()
+    val map = Array(n){ IntArray(n) }
+    val dp = Array(n){ LongArray(n) }
+    val queue: MutableList<Pair<Int, Int>> = mutableListOf()
+
+    queue.add(Pair(0, 0))
+    dp[0][0] = 1L // 시작점에서 출발
+
+    // 맵 값 입력 받기
+    repeat(n) { i ->
+        br.readLine().split(" ").map { it.toInt() }.forEachIndexed { j, value ->
+            map[i][j] = value
+        }
+    }
+
+    for(x in 0 until n){
+        for(y in 0 until n){
+            if(map[x][y]==0 || (x == n - 1 && y == n - 1)) continue
+
+            val newX = x + map[x][y]
+            if (newX < n) { // 경계 체크
+                dp[newX][y] += dp[x][y]
+                queue.add(Pair(newX, y))
+            }
+
+            val newY = y + map[x][y]
+            if (newY < n) { // 경계 체크
+                dp[x][newY] += dp[x][y]
+                queue.add(Pair(x, newY))
+            }
+
+        }
+    }
+
+    // 마지막 지점의 dp 값 출력
+    bw.write(dp[n - 1][n - 1].toString())
+    bw.flush()
+    bw.close()
+    br.close()
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1890
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
최대 100*100인 맵에서 (0,0)에서 (99,99)까지 가는 경우의 수를 구하는 문제
## 🔍 풀이 방법
완전탐색으로 접근하려 했지만 경우의 수가 10최소 50!이상이 나와서 DP로 접근해서 풀었다. dp[x][y]는 현재 좌표까지 오는 경우의 수를 뜻한다
## ⏳ 회고
DP가 좀 더 익숙해지고 있어서 좋은 거 같다. 시간초과 떠서 Queue사용을 할 때는 대충 리스트로 하지말고 내장된 Queue를 쓰자!
