### PR TITLE
[20241022] BAJ / 실버1 / 점프 / 이재인

### DIFF
--- a/JaeIn/202410/22 BAJ 점프.md
+++ b/JaeIn/202410/22 BAJ 점프.md
@@ -1,0 +1,28 @@
+```python
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+board = [list(map(int, input().split())) for _ in range(n)]
+
+dp = [[0] * n for _ in range(n)]
+dp[0][0] = 1
+
+for i in range(n):
+    for j in range(n):
+        if i == n-1 and j == n-1:
+            break
+
+        dist = board[i][j]
+        if dist == 0:
+            continue
+
+        if j + dist < n:
+            dp[i][j + dist] += dp[i][j]
+
+        if i + dist < n:
+            dp[i + dist][j] += dp[i][j]
+
+print(dp[n - 1][n - 1])
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1890
## 🧭 풀이 시간
65분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
가장 왼쪽 위를 시작으로 오른쪽 아래 지점에 도달할 수 있는 경로의 수 구하기
## 🔍 풀이 방법
dp
## ⏳ 회고
처음에는 bfs로 갈 수 있는 경우를 구하고 그 경우일때 queue에  + 1를 하면서 풀었는데 메모리 초과 발생..
이후에도 시간초과가 나서 실패..
풀이를 보니까 쉽게 이해.. 연습이 더 필요
