### PR TITLE
[20241028] BAJ / 실버1 / 절댓값 힙 / 이재인

### DIFF
--- a/JaeIn/202410/28 절대값 힙.md
+++ b/JaeIn/202410/28 절대값 힙.md
@@ -1,0 +1,23 @@
+```python
+import sys
+import heapq
+input = sys.stdin.readline
+
+n = int(input())
+arr = [int(input()) for _ in range(n)]
+
+h = []
+result = []
+for i in arr:
+    if i != 0:
+        heapq.heappush(h , (abs(i) , i))
+    else:
+        if len(h):
+            result.append(heapq.heappop(h)[1])
+        else:
+            result.append(0)
+
+for i in result:
+    print(i)
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11286
## 🧭 풀이 시간
20분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
숫자를 하나씩 넣고 0이 나오는 순간 가장 작은 수를 찾아서 결과값에 추가하는 문제
## 🔍 풀이 방법
우선순위 큐
## ⏳ 회고
우선순위 큐일 경우 앞에 수를 기준으로 판단하기 때문에 이럴 경우 튜플을 사용한다.
입출력 많아 sys를 쓰지 않으면 시간초과 발생