### PR TITLE
[20241029]/BAJ/1890/골드 5/ 김민중

### DIFF
--- a/kmj-99/202410/29 1890.md
+++ b/kmj-99/202410/29 1890.md
@@ -1,0 +1,50 @@
+package com.prototype.codingtest.DP
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+fun main(){
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+    val n = br.readLine().toInt()
+    val map = Array(n){ IntArray(n) }
+    val dp = Array(n){ LongArray(n) }
+    val queue: MutableList<Pair<Int, Int>> = mutableListOf()
+
+    queue.add(Pair(0, 0))
+    dp[0][0] = 1L // 시작점에서 출발
+
+    // 맵 값 입력 받기
+    repeat(n) { i ->
+        br.readLine().split(" ").map { it.toInt() }.forEachIndexed { j, value ->
+            map[i][j] = value
+        }
+    }
+
+    for(x in 0 until n){
+        for(y in 0 until n){
+            if(map[x][y]==0 || (x == n - 1 && y == n - 1)) continue
+
+            val newX = x + map[x][y]
+            if (newX < n) { // 경계 체크
+                dp[newX][y] += dp[x][y]
+                queue.add(Pair(newX, y))
+            }
+
+            val newY = y + map[x][y]
+            if (newY < n) { // 경계 체크
+                dp[x][newY] += dp[x][y]
+                queue.add(Pair(x, newY))
+            }
+
+        }
+    }
+
+    // 마지막 지점의 dp 값 출력
+    bw.write(dp[n - 1][n - 1].toString())
+    bw.flush()
+    bw.close()
+    br.close()
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/status?from_mine=1&problem_id=1890&user_id=nex1223
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
점프로 갈수 있는 경우의 수를 구하는 
## 🔍 풀이 방법
모든 좌표를 돌면서 이전 새로운 좌표로 이동시 이전 좌표 값을 더하는 식으로 접근
## ⏳ 회고
완전탐색이랑 DP 구분을 잘 해야겠다.
