### PR TITLE
[20241108]/PGM/LV2/이모티콘할인행사/김민중

### DIFF
--- a/kmj-99/202411/8 이모티콘할인행사.md
+++ b/kmj-99/202411/8 이모티콘할인행사.md
@@ -1,0 +1,52 @@
+class Solution {
+    private val discounts = arrayOf(10, 20, 30, 40)
+    private lateinit var userList: Array<IntArray>
+    private lateinit var emoticonList: IntArray
+    private var answer = intArrayOf(0, 0)
+
+    fun solution(users: Array<IntArray>, emoticons: IntArray): IntArray {
+        this.userList = users
+        this.emoticonList = emoticons
+        dfs(0, MutableList(users.size) { 0.0 })
+        return answer
+    }
+
+    private fun dfs(index: Int, currentPrices: MutableList<Double>) {
+        // 모든 이모티콘에 대해 할인율을 적용한 경우
+        if (index == emoticonList.size) {
+            var tempUsers = 0
+            var tempPrices = 0.0
+
+            // 사용자가 기준을 충족하는지 확인하고 매출 및 가입자 수 계산
+            for (i in userList.indices) {
+                if (currentPrices[i] >= userList[i][1]) {
+                    tempUsers += 1 // 기준 금액에 도달하면 가입자 수 증가
+                } else {
+                    tempPrices += currentPrices[i] // 기준에 도달하지 않으면 매출에 합산
+                }
+            }
+            
+
+            // 최대 가입자 수 또는 매출을 업데이트
+            if (tempUsers > answer[0] || (tempUsers == answer[0] && tempPrices > answer[1])) {
+                answer[0] = tempUsers
+                answer[1] = tempPrices.toInt()
+            }
+            
+
+            return
+        }
+
+        // 각 할인율을 적용해 DFS 탐색
+        for (discount in discounts) {
+            val newPrices = currentPrices.toMutableList()
+            for (i in userList.indices) {
+                // 할인율이 사용자 기준을 충족할 경우에만 가격 추가
+                if (userList[i][0] <= discount) {
+                    newPrices[i] += emoticonList[index] * ((100-discount)*0.01) // 할인율을 적용한 금액 누적
+                }
+            }
+            dfs(index + 1, newPrices) // 다음 이모티콘으로 이동하여 DFS 수행
+        }
+    }
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/150368
## 🧭 풀이 시간
120분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
모든 유저가 이모티콘을 구매하는 최적의 경우를 구하는 문제. 단, 다음과 같은 우선순위를 고려 1. 이모티콘 구독 서비스 가입자 수 2. 이모티콘 판매량
## 🔍 풀이 방법
DFS를 사용해서 모든 경우의 수를 구해서 최적회 경우를 찾는 식으로 접근
## ⏳ 회고
0.9,0.8이런식으로 계산하니까 1개의 테스트 케이스가 통과가 안되었다. 그래서 (100-10)*0.01, (100-80)*0.01 이런식으로 바꿨더니 통과가 됐다. 아마 소수점 계산이 조금 엇갈려서 그런 거 같다.