### PR TITLE
[20241114] BAJ / 골드4 / 도시 분할 계획 / 김득호

### DIFF
--- a/Ho/202411/12 BAJ RGB거리2.md
+++ b/Ho/202411/12 BAJ RGB거리2.md
@@ -1,0 +1,60 @@
+```java
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class P17404 {
+    static int N;
+    static int[][] costs;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+
+        costs = new int[N][3];
+
+        int ans = (int) 1e9;
+
+        for(int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < 3; j++) {
+                costs[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        for(int i =0; i < 3; i++) {
+            dp = new int[N][3];
+            dp[0][0] = costs[0][i];
+            dp[0][1] = costs[0][i];
+            dp[0][2] = costs[0][i];
+            //처음 스타트 포인트 고정
+            int temp = costs[1][i];
+            costs[1][i] = (int) 1e9 ;
+
+            for(int j = 1; j < N; j++) {
+                dp[j][0] = Math.min(dp[j - 1][1], dp[j - 1][2]) + costs[j][0];
+                dp[j][1] = Math.min(dp[j - 1][0], dp[j - 1][2]) + costs[j][1];
+                dp[j][2] = Math.min(dp[j - 1][0], dp[j - 1][1]) + costs[j][2];
+            }
+
+            for(int j = 0; j < 3; j++) {
+                if(j == i) continue;
+                ans = Math.min(ans, dp[N-1][j]);
+            }
+            costs[1][i] = temp;
+        }
+
+        System.out.println(ans);
+
+
+    }
+}
+
+```

--- a/Ho/202411/13 BAJ 도시 분할 계획.md
+++ b/Ho/202411/13 BAJ 도시 분할 계획.md
@@ -1,0 +1,89 @@
+```java
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class P1647 {
+    static int N,M;
+    static PriorityQueue<Edge> pq = new PriorityQueue<>();
+    static int[] unions;
+
+    static class Edge implements Comparable<Edge>{
+        int cost;
+        int to;
+        int from;
+
+        public Edge(int cost, int to, int from) {
+            this.cost = cost;
+            this.to = to;
+            this.from = from;
+        }
+
+        @Override
+        public int compareTo(Edge o) {
+            return cost - o.cost;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        unions = new int[N];
+        int cnt = 0;
+        for (int i = 0; i < N; i++) {
+            unions[i] = i;
+        }
+
+        for(int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int to = Integer.parseInt(st.nextToken()) - 1;
+            int from = Integer.parseInt(st.nextToken()) - 1;
+            int cost = Integer.parseInt(st.nextToken());
+
+            pq.add(new Edge(cost, to, from));
+        }
+
+        int sum = 0;
+
+        while(!pq.isEmpty()) {
+            Edge curEdge = pq.poll();
+            if(cnt == N-1) break;
+            if(find(curEdge.from) != find(curEdge.to)) {
+                union(curEdge.from,curEdge.to);
+                sum += curEdge.cost;
+                cnt++;
+                if(cnt == N-1) sum -= curEdge.cost;
+            }
+        }
+
+        System.out.println(sum);
+    }
+
+    private static void union(int a, int b) {
+        a = find(a);
+        b = find(b);
+        if (a > b) {
+            unions[a] = b;
+        } else {
+            unions[b] = a;
+        }
+    }
+
+    private static int find(int x) {
+        if (unions[x] == x)
+            return x;
+        else
+            return unions[x] = find(unions[x]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1647
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
마을 내부에 길을 최소, 최적으로 만들고 
2개의 마을로 분리했을때 최소 비용으로 마을 유지하기
## 🔍 풀이 방법
먼저 최소 스패닝트리를 구하고 
제일 비싼 간선을 분리해서 마을을 나눈다.
## ⏳ 회고
