### PR TITLE
[20241118] BAJ / 실버1 / 팔 / 양진혁

### DIFF
--- a/JinHyeok/202411/18 BAJ 팔.md
+++ b/JinHyeok/202411/18 BAJ 팔.md
@@ -1,0 +1,45 @@
+```
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <climits>
+using namespace std;
+
+
+int main() {
+
+	string l, r;
+	cin >> l >> r;
+	int answer = INT_MAX;
+
+	if (r.size() != l.size()) {
+		answer = 0;
+	}
+	else {
+		int cnt = 0;
+		for (int i = 0; i < l.size(); i++) {
+			if (l[i] == '8' || r[i] == '8') {
+				if (l[i] == r[i]) {
+					cnt++;
+				}
+				else {
+					break;
+				}
+			}
+			else {
+				if (l[i] == r[i]) {
+					continue;
+				}
+				else {
+					break;
+				}
+			}
+		}
+		answer = cnt;
+	}
+
+	cout << answer;
+
+	return 0;
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1105
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
주어진 수들 사이에 있는 수중에 숫자 8이 가장 적게 들어가 있는 수중에 8의 개수 출력
## 🔍 풀이 방법
숫자로 입력받아서 완탐으로하면 시초가 나기 때문에 문자열로 입력받아서 조건을 잘 설정하였다.
## ⏳ 회고

처음에는 숫자로 입력받아서 완탐으로 했지만 숫자가 20억까지 받기때문에 시초가 나서
문자열로 입력받아서 문자열의 처음부터 비교해가며 조건을 잘 설정했다
