### PR TITLE
[20241119] BAJ/골드4/타일 채우기/김득호

### DIFF
--- a/Ho/202411/19 BAJ 타일 채우기.md
+++ b/Ho/202411/19 BAJ 타일 채우기.md
@@ -1,0 +1,35 @@
+```java
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class P2133 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[31];
+
+        dp[0] = 1;
+        dp[2] = 3;
+        dp[4] = 11;
+
+        if(n % 2 == 1) {
+            System.out.println(0);
+        }
+        else{
+            for(int i = 4; i <= n; i+=2 ) {
+                dp[i] = dp[i - 2] * dp[2];
+                for(int j = i-4; j >=0; j-=2 ) {
+                    dp[i] = dp[i] + (dp[j] * 2);
+                }
+            }
+            System.out.println(dp[n]);
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [X] 중
- [ ] 하
## ✏️ 문제 설명
3 x n 타일을 
1 x 2, 2 x1 타일로 채우는 경우의 수 구하기
## 🔍 풀이 방법
홀수는 만들 수 없음
짝수의 경우 4 부터 2단위로 새로운 타일이 등장한다.
기존 타일에 추가되는  타일의 경우의 수를 중복없이 계산한다..
## ⏳ 회고
왤케 어렵냐..
