### PR TITLE
[20250115] BAJ/플레4/광고/김득호

### DIFF
--- a/Ho/202501/15 광고.md
+++ b/Ho/202501/15 광고.md
@@ -1,0 +1,34 @@
+```java
+package DataStructure;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class P1305 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int L = Integer.parseInt(br.readLine());
+        String word = br.readLine();
+        word = "#" + word;
+        int maxSize = 1_000_000;
+        int[] f = new int[maxSize + 1];
+
+        f[0] = -1;
+
+        for(int i = 1; i <= L; i++) {
+            int j = f[i- 1];
+
+            while(j >= 0 && word.charAt(j + 1) != word.charAt(i)) {
+                j = f[j];
+            }
+
+            f[i] = j + 1;
+        }
+
+        System.out.println(L - f[L]);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1305
## 🧭 풀이 시간
20분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
문제에서 제시하는 광고를 출력하기 위한 최소 글자 수는 몇인가?
## 🔍 풀이 방법
KMP의 실패 함수를 이용해서 접두사와 접미사랑 겹치는 최대 거리만큼 
광고판에서 빼주면 된다.

## ⏳ 회고
꾸준히 풀면서 해당 유형 빠르게 풀기
