### PR TITLE
[20250117] BAJ / 골드4 / 가장 긴 바이토닉 부분 수열 / 양진혁

### DIFF
--- a/JinHyeok/202501/17 BAJ 가장 긴 바이토닉 부분수열.md
+++ b/JinHyeok/202501/17 BAJ 가장 긴 바이토닉 부분수열.md
@@ -1,0 +1,60 @@
+```
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+vector<int> v;
+int left_size[1001];
+int right_size[1001];
+int answer;
+
+int main() {
+
+	int n;
+	cin >> n;
+
+
+	for (int i = 0; i < n; i++) {
+		int a;
+		cin >> a;
+		v.push_back(a);
+	}
+
+	for (int i = 0; i < n; i++) {
+		int a;
+		cin >> a;
+		v.push_back(a);
+	}
+
+	for (int i = 0; i < n; i++) {
+		left_size[i] = 1;
+		right_size[i] = 1;
+	}
+
+	for (int i = 0; i < n; i++) {
+		for (int j = 0; j < i; j++) {
+			if (v[i] > v[j]) {
+				left_size[i] = max(left_size[i], left_size[j] + 1);
+			}
+		}
+	}
+
+	for (int i = n - 1; i >= 0; i--) {
+		for (int j = n-1; j > i; j--) {
+			if (v[i] > v[j]) {
+				right_size[i] = max(right_size[i], right_size[j] + 1);
+			}
+		}
+	}
+
+	for (int i = 0; i < n; i++) {
+		answer = max(answer, left_size[i] + right_size[i]);
+	}
+
+
+	cout << answer - 1;
+
+	return 0;
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11054
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [X] 하
## ✏️ 문제 설명
가장 긴 바이토닉 부분 수열의 길이를 구하는 문제
## 🔍 풀이 방법
DP
## ⏳ 회고
그냥 DP 배열을 두개써서 나중에 합치면된다
