### PR TITLE
[20250131]/BJ/골드3/벽부수고이동하기

### DIFF
--- a/kmj-99/202501/31 벽부수고이동하기.md
+++ b/kmj-99/202501/31 벽부수고이동하기.md
@@ -1,0 +1,85 @@
+```java
+
+import java.io.*;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int N = 0;
+    static int M = 0;
+    static int answer = 1000000;
+    static int[] dx = {0,-1,0,1};
+    static int[] dy = {1,0,-1,0};
+    static Integer[][] maps;
+    static boolean[][][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        maps = new Integer[N][M];
+        visited = new boolean[N][M][2];
+
+        for(int i = 0; i<N; i++){
+            String str=br.readLine();
+            for(int j = 0; j<M; j++){
+                maps[i][j]=Integer.parseInt(String.valueOf(str.charAt(j)));
+            }
+        }
+        answer = bfs();
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+        bw.close();
+    }
+
+    public static int bfs(){
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{0,0,0,1});
+        visited[0][0][0]=true;
+
+        while(!queue.isEmpty()){
+            int[] cur = queue.poll();
+            int x = cur[0];
+            int y = cur[1];
+            int isBreak = cur[2];
+            int dist = cur[3];
+
+            if(y==N-1 && x==M-1) return dist;
+
+
+            for(int i = 0; i<4; i++){
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+
+                if(nx>=M || nx<0 || ny>=N || ny<0) continue;
+
+
+                if(maps[ny][nx] == 0 && !visited[ny][nx][isBreak]){
+                    visited[ny][nx][isBreak] = true;
+                    queue.offer(new int[]{nx,ny,isBreak,dist+1});
+                }
+
+                if(maps[ny][nx] == 1 && isBreak==0 && !visited[ny][nx][isBreak]){
+                    visited[ny][nx][isBreak] = true;
+                    queue.offer(new int[]{nx, ny, 1, dist+1});
+                }
+            }
+
+        }
+
+
+        return -1;
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2206
## 🧭 풀이 시간
120분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
N×M의 행렬로 표현되는 맵이 있다. 맵에서 0은 이동할 수 있는 곳을 나타내고, 1은 이동할 수 없는 벽이 있는 곳을 나타낸다. 당신은 (1, 1)에서 (N, M)의 위치까지 이동하려 하는데, 이때 최단 경로로 이동하려 한다. 최단경로는 맵에서 가장 적은 개수의 칸을 지나는 경로를 말하는데, 이때 시작하는 칸과 끝나는 칸도 포함해서 센다.

만약에 이동하는 도중에 한 개의 벽을 부수고 이동하는 것이 좀 더 경로가 짧아진다면, 벽을 한 개 까지 부수고 이동하여도 된다.

한 칸에서 이동할 수 있는 칸은 상하좌우로 인접한 칸이다.

맵이 주어졌을 때, 최단 경로를 구해 내는 프로그램을 작성하시오.
## 🔍 풀이 방법
처음에 dfs로 접근했다가 시간초과가 나서 bfs로 풀었다. 벽을 부순 상태와 벽을 부수지 않는 상태를 구분해서 가야한다는 점이 생각하기 어려웠다. 벽을 부순 상태에서 가다가 마지막에 벽이 있으면 결국 도착지로 못간다. 벽을 안부순상태에서 가면 도착지로 갈 수 있지만 이미 벽을 부순상태에서 간 길이 visited = true이기에 도착지에 도달하지 못한다. 이때문에 visited[N][M][2] 이런식으로 3차원 배열을 사용해서 벽을 부순 상태와 그렇지 않은 상태로 구분해서 접근을 해야한다.
## ⏳ 회고
분기를 나누는 게 쉽지 않았다.
