### PR TITLE
[20250204]/Softeer/LV5/축제

### DIFF
--- a/kmj-99/202502/4 축제.md
+++ b/kmj-99/202502/4 축제.md
@@ -1,0 +1,127 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+/*
+
+    calu(node = i, focusNode,res = L[node][i], visited);
+    이런식을 코드를 작성하면 문제가 발생한다. 자바에서 함수를 호출하면 = 계산을 먼저 처리한다. 그럼 함수가 호출되기전 node가 i로 바뀌므로 최종적으로 res = L[i][i]가 된다.
+    이 부분을 유의하자
+ */
+
+public class Main {
+    static int N = 0;
+    static int Q = 0;
+
+    static HashMap<Integer,List<Integer>> nodes = new HashMap<Integer,List<Integer>>();
+    static int[][] L;
+
+    static int[] galf;
+
+    static ArrayList<String> V = new ArrayList<>();
+
+    static int answer = 0;
+    static int resTemp = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        boolean[] visited= new boolean[N+1];
+        galf = new int[N+1];
+        L = new int[N+1][N+1];
+
+        StringTokenizer stt = new StringTokenizer(br.readLine());
+        for(int i=1; i<N+1; i++){
+            galf[i] = Integer.parseInt(stt.nextToken());
+        }
+
+        for (int i = 0; i < N-1; i++) {
+            StringTokenizer st2 = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st2.nextToken());
+            int y = Integer.parseInt(st2.nextToken());
+            int dist = Integer.parseInt(st2.nextToken());
+
+            L[x][y] = dist;
+            L[y][x] = dist;
+
+                if(!nodes.containsKey(x)){
+                    nodes.put(x,new ArrayList<>(Arrays.asList(y)));
+                }else{
+                    nodes.get(x).add(y);
+                }
+
+                if(!nodes.containsKey(y)){
+                    nodes.put(y,new ArrayList<>(Arrays.asList(x)));
+                }else{
+                    nodes.get(y).add(x);
+                }
+
+
+        }
+
+        StringTokenizer st3 = new StringTokenizer(br.readLine());
+        Q = Integer.parseInt(st3.nextToken());
+
+        V.add("");
+        for (int i = 0; i < Q; i++) {
+            V.add(br.readLine());
+        }
+
+
+
+        for(int i = 1; i<Q+1; i++){
+            if(Objects.equals(V.get(i).split(" ")[0], "1")){
+                String[] temp = V.get(i).split(" ");
+                for(int j : nodes.keySet()){
+
+                    calu(j,Integer.parseInt(temp[1]),0,copyList(visited));
+                    answer += (resTemp*galf[j]);
+                    resTemp = 0;
+                }
+            }else if(Objects.equals(V.get(i).split(" ")[0], "2")){
+                String[] temp = V.get(i).split(" ");
+                galf[Integer.parseInt(temp[1])]+= Integer.parseInt(temp[2]);
+                continue;
+            }
+
+            System.out.println(answer);
+            answer = 0;
+        }
+
+
+    }
+
+    public static void calu(int node, int focusNode, int res, boolean[] visited){
+        visited[node] = true;
+        if(node == focusNode){
+            resTemp = res;
+            return;
+        }
+
+        if(!nodes.containsKey(node)) return;
+
+        for(int i : nodes.get(node)){
+            if(visited[i]) continue;
+            visited[i] = true;
+            calu(i, focusNode,res+L[node][i], visited);
+        }
+
+    }
+
+    public static boolean[] copyList(boolean[] visited){
+        boolean[] temp = new boolean[visited.length+1];
+        for(int i = 1; i< visited.length; i++){
+            temp[i] = visited[i];
+        }
+        return temp;
+    }
+
+
+}
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://softeer.ai/app/assessment/index.html?xid=359663&xsrfToken=3b7BmwSA3MISmmhoE9UUYNB2hWErEVeG&testType=practice
## 🧭 풀이 시간
200분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
자연을 사랑하는 요정 깐프들은 거대한 나무, 세계수에 산다. 세계수는 N개의 정점으로 이루어진 트리로 표현할 수 있다. 정점에는 1에서 N까지 번호가 붙어 있으며, 처음에 i번 정점에는 Gi​명의 깐프들이 살고 있다.

두 정점은 하나의 가지로 연결되어 있어 깐프들은 가지를 따라 정점 사이를 양방향으로 이동할 수 있다. 가지는 총 N−1개 있으며, 임의의 두 정점 사이 이동이 가능하도록 연결되어 있다. 가지에도 1에서 N−1까지의 번호가 붙어 있으며, i번 가지는 Xi​번 정점과 Yi​번 정점을 연결하는 길이가 Li​인 가지이다.

수명이 긴 깐프들에게 앞으로 Q번의 이벤트가 일어난다. i번째 이벤트는 다음 2 종류 중 하나와 같다.

vi​번 정점에서 세계수에 사는 모든 깐프들이 모이는 축제를 연다.
vi​번 정점에 새로운 깐프가 gi​명 더 태어나 살게 된다.
1번 종류의 이벤트에서 깐프들은 수가 매우 많기 때문에, 모든 깐프들이 세계수의 가지를 따라 이동하는 과정에서 세계수에 많은 부담이 간다. 하지만 축제에는 모든 깐프가 참여해야 하기에, 어느 정도 부담이 가는지 미리 계산해서 적절히 세계수를 관리하고자 한다.

축제가 일어나 깐프들이 이동할 때, 세계수에 가해지는 부담은 각 정점에 사는 모든 깐프들이 vi​번 정점으로 이동한 거리들의 합으로 계산한다. 깐프들은 세계수에 부담을 최소화하기 위해 자신이 사는 정점에서 다른 정점으로 이동할 때 항상 최단 거리로 이동한다.

추가로 1번 이벤트들은 서로 독립적이다. 따라서 축제를 위해 모인 후 모든 깐프는 자신이 원래 있던 정점으로 돌아간다. 돌아가는 길은 세계수에 부담이 되지 않는다.

이벤트들이 일어난 순서대로 주어질 때, 1번 종류의 이벤트가 주어질 때마다 세계수에 가해지는 부담을 구해 출력하는 프로그램을 작성하라.
## 🔍 풀이 방법
dfs를 활용해서 세계수의 가해지는 부담을 구했다. 테스트케이스는 통과했지만 히든 테케에서 시간초과, 런타임에러가 뜬다. 6*104*6*104라서 시간초괴는 안 뜰 거 같은데, 런타임 에러는 왜 뜨는지,, 아직 해결하진 못했다.
## ⏳ 회고
내일 다시 풀어봐야지,,
