### PR TITLE
[20250205]/Softeer/LV5/축제

### DIFF
--- a/kmj-99/202502/5 축제.md
+++ b/kmj-99/202502/5 축제.md
@@ -1,0 +1,139 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+
+public class Main {
+    static int N, Q;
+    static int[] galf, depth, dist;
+    static int[][] parent;
+    static ArrayList<int[]>[] tree;
+    static ArrayList<String> queries = new ArrayList<>();
+    static final int LOG = 17; // 2^17 > 60,000
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        galf = new int[N + 1];
+        depth = new int[N + 1];
+        dist = new int[N + 1];
+        parent = new int[N + 1][LOG];
+        tree = new ArrayList[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            tree[i] = new ArrayList<>();
+        }
+
+        // 각 노드의 초기 가중치 입력
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            galf[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 트리 간선 입력
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+            tree[x].add(new int[]{y, d});
+            tree[y].add(new int[]{x, d});
+        }
+
+        // DFS를 이용해 부모, 깊이, 거리 전처리
+        dfs(1, 0, 0, 0);
+        preprocess();
+
+        // 질의 개수 입력
+        Q = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < Q; i++) {
+            String[] query = br.readLine().split(" ");
+            if (query[0].equals("1")) {
+                int v = Integer.parseInt(query[1]);
+                long answer = 0;
+                for (int j = 1; j <= N; j++) {
+                    int lcaDist = getDistance(j, v);
+                    answer += (long) lcaDist * galf[j];
+                }
+                sb.append(answer).append("\n");
+            } else {
+                int gIndex = Integer.parseInt(query[1]);
+                int addValue = Integer.parseInt(query[2]);
+                galf[gIndex] += addValue;
+            }
+        }
+
+        System.out.print(sb.toString());
+    }
+
+    // DFS를 통해 부모, 깊이, 루트로부터 거리 정보 저장
+    static void dfs(int node, int par, int d, int distance) {
+        parent[node][0] = par;
+        depth[node] = d;
+        dist[node] = distance;
+
+        for (int[] next : tree[node]) {
+            int child = next[0], cost = next[1];
+            if (child != par) {
+                dfs(child, node, d + 1, distance + cost);
+            }
+        }
+    }
+
+    // 희소 테이블을 이용한 부모 정보 전처리 (O(N log N))
+    static void preprocess() {
+        for (int j = 1; j < LOG; j++) {
+            for (int i = 1; i <= N; i++) {
+                if (parent[i][j - 1] != 0) {
+                    parent[i][j] = parent[parent[i][j - 1]][j - 1];
+                }
+            }
+        }
+    }
+
+    // LCA를 사용한 두 노드 사이 거리 계산 (O(log N))
+    static int getDistance(int u, int v) {
+        int lcaNode = getLCA(u, v);
+        return dist[u] + dist[v] - 2 * dist[lcaNode];
+    }
+
+    // 최소 공통 조상 (LCA) 구하기 (O(log N))
+    static int getLCA(int u, int v) {
+        if (depth[u] < depth[v]) {
+            int temp = u;
+            u = v;
+            v = temp;
+        }
+
+        // 깊이를 맞추기
+        int diff = depth[u] - depth[v];
+        for (int i = 0; i < LOG; i++) {
+            if ((diff & (1 << i)) != 0) {
+                u = parent[u][i];
+
+            }
+        }
+
+        if (u == v) return u;
+
+        // 공통 조상을 찾기
+        for (int i = LOG - 1; i >= 0; i--) {
+            if (parent[u][i] != parent[v][i]) {
+                u = parent[u][i];
+                v = parent[v][i];
+            }
+        }
+
+        return parent[u][0];
+    }
+
+}
+
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://softeer.ai/practice/11005/history?questionType=ALGORITHM
## 🧭 풀이 시간
500분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
자연을 사랑하는 요정 깐프들은 거대한 나무, 세계수에 산다. 세계수는 N개의 정점으로 이루어진 트리로 표현할 수 있다. 정점에는 1에서 N까지 번호가 붙어 있으며, 처음에 i번 정점에는 Gi​명의 깐프들이 살고 있다.

두 정점은 하나의 가지로 연결되어 있어 깐프들은 가지를 따라 정점 사이를 양방향으로 이동할 수 있다. 가지는 총 N−1개 있으며, 임의의 두 정점 사이 이동이 가능하도록 연결되어 있다. 가지에도 1에서 N−1까지의 번호가 붙어 있으며, i번 가지는 Xi​번 정점과 Yi​번 정점을 연결하는 길이가 Li​인 가지이다.

수명이 긴 깐프들에게 앞으로 Q번의 이벤트가 일어난다. i번째 이벤트는 다음 2 종류 중 하나와 같다.

vi​번 정점에서 세계수에 사는 모든 깐프들이 모이는 축제를 연다.
vi​번 정점에 새로운 깐프가 gi​명 더 태어나 살게 된다.
1번 종류의 이벤트에서 깐프들은 수가 매우 많기 때문에, 모든 깐프들이 세계수의 가지를 따라 이동하는 과정에서 세계수에 많은 부담이 간다. 하지만 축제에는 모든 깐프가 참여해야 하기에, 어느 정도 부담이 가는지 미리 계산해서 적절히 세계수를 관리하고자 한다.

축제가 일어나 깐프들이 이동할 때, 세계수에 가해지는 부담은 각 정점에 사는 모든 깐프들이 vi​번 정점으로 이동한 거리들의 합으로 계산한다. 깐프들은 세계수에 부담을 최소화하기 위해 자신이 사는 정점에서 다른 정점으로 이동할 때 항상 최단 거리로 이동한다.

추가로 1번 이벤트들은 서로 독립적이다. 따라서 축제를 위해 모인 후 모든 깐프는 자신이 원래 있던 정점으로 돌아간다. 돌아가는 길은 세계수에 부담이 되지 않는다.

이벤트들이 일어난 순서대로 주어질 때, 1번 종류의 이벤트가 주어질 때마다 세계수에 가해지는 부담을 구해 출력하는 프로그램을 작성하라.
## 🔍 풀이 방법
처음에 dfs를 활용해 전체 노드를 탐색했는데 시간초과가 떴다. 그래서 트리를 구성하여 LCA를 활용해서 세계수를 구했다. 그러니까 Subtask2까지는 정답이었지만 Subtask3은 시간초과가 떴다. 분명 logN*Q로 시간복잡도를 줄였는데 시간초과가 떴다. 그래서 내가 시간복잡도를 잘못 계산했는지 확인하고, 아니라면 시간복잡도를 더 줄이도록 로직을 수정해야겠다.
## ⏳ 회고
Softeer 문제 왜케 어려움
