### PR TITLE
[20250207]/BJ/골드2/2169/김민중

### DIFF
--- a/kmj-99/202502/7 2169.md
+++ b/kmj-99/202502/7 2169.md
@@ -1,0 +1,67 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M;
+    static int[][] map, dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new int[N + 1][M + 1];
+        dp = new int[N + 1][M + 1];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // DP 초기화
+        dp[1][1] = map[1][1];
+
+        // 첫 번째 행은 왼쪽에서만 올 수 있음
+        for (int x = 2; x <= M; x++) {
+            dp[1][x] = dp[1][x - 1] + map[1][x];
+        }
+
+        // 나머지 부분 채우기
+        for (int y = 2; y <= N; y++) {
+            int[] leftToRight = new int[M + 1];
+            int[] rightToLeft = new int[M + 1];
+
+            // 왼쪽에서 오는 경우
+            leftToRight[1] = dp[y - 1][1] + map[y][1];
+            for (int x = 2; x <= M; x++) {
+                leftToRight[x] = Math.max(leftToRight[x - 1], dp[y - 1][x]) + map[y][x];
+            }
+
+            // 오른쪽에서 오는 경우
+            rightToLeft[M] = dp[y - 1][M] + map[y][M];
+            for (int x = M - 1; x >= 1; x--) {
+                rightToLeft[x] = Math.max(rightToLeft[x + 1], dp[y - 1][x]) + map[y][x];
+            }
+
+            // 최종 값 갱신
+            for (int x = 1; x <= M; x++) {
+                dp[y][x] = Math.max(leftToRight[x], rightToLeft[x]);
+            }
+        }
+
+        bw.write(String.valueOf(dp[N][M]));
+        bw.flush();
+        bw.close();
+    }
+}
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2169
## 🧭 풀이 시간
200분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
NASA에서는 화성 탐사를 위해 화성에 무선 조종 로봇을 보냈다. 실제 화성의 모습은 굉장히 복잡하지만, 로봇의 메모리가 얼마 안 되기 때문에 지형을 N×M 배열로 단순화 하여 생각하기로 한다.

지형의 고저차의 특성상, 로봇은 움직일 때 배열에서 왼쪽, 오른쪽, 아래쪽으로 이동할 수 있지만, 위쪽으로는 이동할 수 없다. 또한 한 번 탐사한 지역(배열에서 하나의 칸)은 탐사하지 않기로 한다.

각각의 지역은 탐사 가치가 있는데, 로봇을 배열의 왼쪽 위 (1, 1)에서 출발시켜 오른쪽 아래 (N, M)으로 보내려고 한다. 이때, 위의 조건을 만족하면서, 탐사한 지역들의 가치의 합이 최대가 되도록 하는 프로그램을 작성하시오.
## 🔍 풀이 방법
처음에 dfs로 접근했다가 시간초과가 나서 dp로 풀었다.
## ⏳ 회고
dp는 역시 어렵
