### PR TITLE
[20250210] BAJ / G1 / 계단 수 / 신희을

### DIFF
--- a/ShinHeeEul/202502/10 BAJ G1 계단 수.md
+++ b/ShinHeeEul/202502/10 BAJ G1 계단 수.md
@@ -1,0 +1,52 @@
+```java
+import java.util.*;
+
+import java.io.*;
+
+public class Main {
+
+    static long[][][] dp;
+    static int N;
+    static final long MOD = 1000000000L;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+            if (N <= 9) {
+                System.out.println(0);
+                return;
+            }
+
+            // i는 현재 길이
+            // j는 마지막 값
+            // k는 현재 방문 값
+            dp = new long[N + 1][10][(1 << 10)];
+
+            for(int i = 1; i < 10; i++) {
+                dp[1][i][(1 << i)] = 1;
+            }
+
+            for(int i = 2; i <= N; i++) {
+                for(int j = 0; j < 10; j++) {
+                    for(int k = 0; k < (1 << 10); k++) {
+                        if(j == 0) dp[i][j][k | ( 1 << j)] += dp[i - 1][j + 1][k] %MOD;
+                        else if(j == 9) dp[i][j][k | ( 1 << j)] += dp[i-1][j - 1][k] %MOD;
+                        else dp[i][j][k | ( 1 << j)] += (dp[i-1][j-1][k] + dp[i-1][j+1][k]) %MOD;
+                    }
+                }
+            }
+
+            long sum = 0;
+
+            for(int j = 0; j < 10; j++) {
+                    sum += dp[N][j][(1<< 10) - 1] %MOD;
+            }
+
+            System.out.println(sum % MOD);
+
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1562
## 🧭 풀이 시간
540 분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
45656이란 수를 보자.

이 수는 인접한 모든 자리의 차이가 1이다. 이런 수를 계단 수라고 한다.

N이 주어질 때, 길이가 N이면서 0부터 9까지 숫자가 모두 등장하는 계단 수가 총 몇 개 있는지 구하는 프로그램을 작성하시오. 0으로 시작하는 수는 계단수가 아니다.

## 🔍 풀이 방법
3차원 DP + 비트 마스킹
dp[길이][마지막 수][이제까지 나온 수 비트 마스킹] 으로 두고
`dp[i][j][k | j] += dp[i-1][j+1][k] + dp[i][j-1][k]`을 점화식으로 세운다. dp 배열을 다 채운 후, 길이가 N이면서 0~9까지 모두 나온 값들을 전부 더해서 구해준다.

## ⏳ 회고
앞에서부터 차근차근 쌓아가도 되었는데, 중간에서 시작해 양쪽으로 확장하면서 비교하려고 한게 화근이었다. 중복을 잡을 수가 없더라. 그리고 이제껏 백트래킹을 이용한 비트마스킹만 풀어왔는데, 그렇지 않은 문제도 있다는 것을 알게 되었다.