### PR TITLE
[20250216]/BJ/실버5/막대기/김민중

### DIFF
--- a/kmj-99/202502/16 막대기
+++ b/kmj-99/202502/16 막대기
@@ -1,0 +1,34 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.*;
+
+public class Main {
+    static int N;
+    static int answer = 0;
+
+    public static void main(String[] args) throws Exception {
+        StringTokenizer st;
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        String x =Integer.toBinaryString(N);
+
+        for(int i = 0; i<x.length(); i++){
+            if(x.charAt(i)=='1') answer++;
+        }
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+        bw.close();
+
+
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1094
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
지민이는 길이가 64cm인 막대를 가지고 있다. 어느 날, 그는 길이가 Xcm인 막대가 가지고 싶어졌다. 지민이는 원래 가지고 있던 막대를 더 작은 막대로 자른다음에, 풀로 붙여서 길이가 Xcm인 막대를 만들려고 한다.

막대를 자르는 가장 쉬운 방법은 절반으로 자르는 것이다. 지민이는 아래와 같은 과정을 거쳐서 막대를 자르려고 한다.

지민이가 가지고 있는 막대의 길이를 모두 더한다. 처음에는 64cm 막대 하나만 가지고 있다. 이때, 합이 X보다 크다면, 아래와 같은 과정을 반복한다.
가지고 있는 막대 중 길이가 가장 짧은 것을 절반으로 자른다.
만약, 위에서 자른 막대의 절반 중 하나를 버리고 남아있는 막대의 길이의 합이 X보다 크거나 같다면, 위에서 자른 막대의 절반 중 하나를 버린다.
이제, 남아있는 모든 막대를 풀로 붙여서 Xcm를 만든다.
X가 주어졌을 때, 위의 과정을 거친다면, 몇 개의 막대를 풀로 붙여서 Xcm를 만들 수 있는지 구하는 프로그램을 작성하시오. 
## 🔍 풀이 방법
비트마스킹을 적용하여 x를 이진수로 바꾸고 1의 개수만큼 막대기가 필요하므로 1의 개수가 곧 답이뵌다.
## ⏳ 회고
비트마스킹을 통해 푸는 방법이 신박하다.
