### PR TITLE
[20250222]/BJ/골드4/줄세우기/김민중

### DIFF
--- a/kmj-99/202502/22 줄세우기
+++ b/kmj-99/202502/22 줄세우기
@@ -1,0 +1,41 @@
+```java
+
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+
+        int[] d = new int[n + 1];  // LIS 길이를 저장하는 배열
+        int[] num = new int[n + 1]; // 입력 숫자 배열 (1-based index)
+        
+        for (int i = 1; i <= n; i++) {
+            num[i] = sc.nextInt();
+            d[i] = 1; // LIS 초기값 1로 설정
+        }
+
+        // 가장 긴 증가하는 부분 수열 찾기 (O(n^2) 방식)
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j < i; j++) {
+                if (num[j] < num[i]) {
+                    d[i] = Math.max(d[i], d[j] + 1);
+                }
+            }
+        }
+
+        // LIS의 최대 길이 찾기
+        int maxLIS = 0;
+        for (int i = 1; i <= n; i++) {
+            maxLIS = Math.max(maxLIS, d[i]);
+        }
+
+        // n - LIS 길이 = 제거해야 하는 최소 개수
+        System.out.println(n - maxLIS);
+
+        sc.close();
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2631
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
KOI 어린이집에는 N명의 아이들이 있다. 오늘은 소풍을 가는 날이다. 선생님은 1번부터 N번까지 번호가 적혀있는 번호표를 아이들의 가슴에 붙여주었다. 선생님은 아이들을 효과적으로 보호하기 위해 목적지까지 번호순서대로 일렬로 서서 걸어가도록 하였다. 이동 도중에 보니 아이들의 번호순서가 바뀌었다. 그래서 선생님은 다시 번호 순서대로 줄을 세우기 위해서 아이들의 위치를 옮기려고 한다. 그리고 아이들이 혼란스러워하지 않도록 하기 위해 위치를 옮기는 아이들의 수를 최소로 하려고 한다.

예를 들어, 7명의 아이들이 다음과 같은 순서대로 줄을 서 있다고 하자.

3 7 5 2 6 1 4

아이들을 순서대로 줄을 세우기 위해, 먼저 4번 아이를 7번 아이의 뒤로 옮겨보자. 그러면 다음과 같은 순서가 된다.

3 7 4 5 2 6 1

이제, 7번 아이를 맨 뒤로 옮긴다.

3 4 5 2 6 1 7

다음 1번 아이를 맨 앞으로 옮긴다.

1 3 4 5 2 6 7

마지막으로 2번 아이를 1번 아이의 뒤로 옮기면 번호 순서대로 배치된다.

1 2 3 4 5 6 7

위의 방법으로 모두 4명의 아이를 옮겨 번호 순서대로 줄을 세운다. 위의 예에서 3명의 아이만을 옮겨서는 순서대로 배치할 수가 없다. 따라서, 4명을 옮기는 것이 가장 적은 수의 아이를 옮기는 것이다.

N명의 아이들이 임의의 순서로 줄을 서 있을 때, 번호 순서대로 배치하기 위해 옮겨지는 아이의 최소 수를 구하는 프로그램을 작성하시오.
## 🔍 풀이 방법
최대 증가하는 부분수열의 길이를 전체 길이에서 빼면 된다. 그러면 남은 수들은 바꿔야 하는 수의 최소이다.
## ⏳ 회고
최대 증가하는 부분수열의 길이를 생각해내는 게 쉽지 않았다.
