### PR TITLE
[20250228]/BJ/골드4/1027/김민중

### DIFF
--- a/kmj-99/202502/28 1027
+++ b/kmj-99/202502/28 1027
@@ -1,0 +1,59 @@
+```java
+
+	import java.io.*;
+import java.util.*;
+ 
+public class Main {
+    static int[] map;
+    static int N;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        
+        N = Integer.parseInt(br.readLine());
+        map = new int[N];
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i=0; i<N; i++) {
+            map[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        int ans = 0;
+        for (int i=0; i<N; i++) {
+            ans = Math.max(ans, Count(i));
+        }
+        
+        System.out.println(ans);
+    }
+    
+    public static int Count(int idx) {
+        int cnt = 0;
+        double tmp = 0;
+        
+        // 왼쪽
+        for (int i=idx-1; i>=0; i--) {
+            double slope = (double) (map[idx] - map[i]) / (idx - i);
+           
+            if (i == idx-1 || tmp > slope) {
+                cnt++;
+                tmp = slope;
+            }
+        }
+        
+        // 오른쪽
+        for (int i=idx+1; i<N; i++) {
+            double slope = (double) (map[idx] - map[i]) / (idx - i);
+            
+            if (i == idx+1 || tmp < slope) {
+                cnt++;
+                tmp = slope;
+            }
+        }
+        
+        return cnt;
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1027
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
세준시에는 고층 빌딩이 많다. 세준시의 서민 김지민은 가장 많은 고층 빌딩이 보이는 고층 빌딩을 찾으려고 한다. 빌딩은 총 N개가 있는데, 빌딩은 선분으로 나타낸다. i번째 빌딩 (1부터 시작)은 (i,0)부터 (i,높이)의 선분으로 나타낼 수 있다. 고층 빌딩 A에서 다른 고층 빌딩 B가 볼 수 있는 빌딩이 되려면, 두 지붕을 잇는 선분이 A와 B를 제외한 다른 고층 빌딩을 지나거나 접하지 않아야 한다. 가장 많은 고층 빌딩이 보이는 빌딩을 구하고, 거기서 보이는 빌딩의 수를 출력하는 프로그램을 작성하시오.
## 🔍 풀이 방법
기울기 구해서 양쪽으로 비교하면 된다.
## ⏳ 회고
쉽다.
