### PR TITLE
[20250304] BAJ/P5/곡선 자르기/김득호

### DIFF
--- a/Ho/202503/4 곡선 자르기.md
+++ b/Ho/202503/4 곡선 자르기.md
@@ -1,0 +1,141 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static ArrayList<Pair> ps1 = new ArrayList<>();
+    static ArrayList<Pair> ps2 = new ArrayList<>();
+    static ArrayDeque<Point> stack = new ArrayDeque<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        Pair[] pairs = new Pair[N];
+        int minX = Integer.MAX_VALUE;
+        int idx = 0;
+
+        for(int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            pairs[i] = new Pair(x, y);
+            if(minX >= x) {
+                minX = x;
+                if(y < 0) idx = i;
+            }
+        }
+
+        int preX = minX;
+        int preY = pairs[idx].y;
+        int temp[] = new int[2];
+        int tIdx = 0;
+        int group = 0;
+
+        //x가 가장 작고 y또한 음수인 경우부터 시작
+        for(int i = 1; i < N; i++) {
+            idx =  (idx + 1) % N;
+            // 봉우리 찾기 ㄱㄱ
+            if(pairs[idx].x == preX && ((preY < 0 && pairs[idx].y > 0) || (preY > 0 && pairs[idx].y < 0))) {
+                temp[tIdx++] = pairs[idx].x;
+                tIdx %= 2;
+
+                if(tIdx == 0) {
+                    //봉우리인 경우
+                    int x1= Math.min(temp[0],temp[1]);
+                    int x2 = Math.max(temp[0], temp[1]);
+
+                    //작업하기
+                    ps1.add(new Pair(x1, x2,group));
+                    ps2.add(new Pair(x2, x1,group++));
+                }
+            }
+            preX = pairs[idx].x;
+            preY = pairs[idx].y;
+        }
+
+        Collections.sort(ps1);
+        Collections.sort(ps2);
+
+        Point[] points = new Point[ps1.size() * 2];
+
+        int iidx = 0;
+
+        for(int i = 0; i < ps1.size(); i++) {
+            points[iidx++] = new Point(ps1.get(i).x, ps1.get(i).g);
+            points[iidx++] = new Point(ps2.get(i).x, ps2.get(i).g);
+        }
+
+        Arrays.sort(points);
+
+        boolean[] includeCheck = new boolean[group];
+
+        int notIncludeCnt = 0; // 아무한테도 포함안되는거
+        int cnt = 0; // 포함되는거
+
+        for(int i = 0; i < points.length; i++) {
+            if(stack.isEmpty()) {
+                notIncludeCnt++;
+                stack.push(points[i]);
+                continue;
+            }
+
+            if(stack.peekFirst().idx != points[i].idx) {
+                // 넣어야지
+                includeCheck[stack.peekFirst().idx] = true;
+                stack.push(points[i]);
+            }
+            else {
+                //같은 경우 pop 빼야지
+                if(!includeCheck[stack.peekFirst().idx]) cnt++;
+                stack.poll();
+            }
+        }
+
+        System.out.println(notIncludeCnt + " " + cnt);
+    }
+
+
+    static class Pair implements Comparable<Pair> {
+        int x;
+        int y;
+        int g;
+
+        Pair(int x, int y){
+            this.x = x;
+            this.y = y;
+        }
+
+        Pair(int x, int y, int g){
+            this.x = x;
+            this.y = y;
+            this.g = g;
+        }
+
+        @Override
+        public int compareTo(Pair o) {
+            return Integer.compare(this.x, o.x);
+        }
+    }
+
+    static class Point implements Comparable<Point>{
+        int x;
+        int idx;
+
+        Point(int x , int idx) {
+            this.x = x ;
+            this.idx = idx;
+        }
+
+        @Override
+        public int compareTo(Point o) {
+            return this.x - o.x;
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14865
## 🧭 풀이 시간
300분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
x축을 기준으로 잘랐을 떄 봉우리를 포함하고 있는 봉우리 개수와 어떤 봉우리도 
포함하지 않고 있는 봉우리 개수를 출력하시오.

## 🔍 풀이 방법
문제에 입력 값은 제시한 패턴을 기준으로 주어진다. 반시계방향으로 주어지기 떄문에
맨 왼쪽 아래 점을 잡고 모든 음수에서 양수로 변경하는 x1 좌표  양수 -> 음수로 변경되는 x2 좌표
이 구간이 봉우리다.
이렇게 구한 봉우리를 x1을 기준으로 정렬한다. 
이때부터는 스택 "(" , ")"  넣고 빼고하는 문제랑 같이 x1 과 x2가 작은 것부터 배열에 넣어서 
정렬한걸 기준으로 스택을 이용한다. 
## ⏳ 회고
너무 구현을 더럽게했다 그리고ㅓ
진짜 오래걸렸다 구현 문제는 깔끔하게 정리하고 코드도 잘 정리해서 풀기
