### PR TITLE
[20250305]/BJ/골드5/22251/김민중

### DIFF
--- a/kmj-99/202503/5 22251.md
+++ b/kmj-99/202503/5 22251.md
@@ -1,0 +1,72 @@
+```java
+import java.io.*;
+import java.util.*;
+ 
+public class Main {
+ 
+    static int n, k, p, x;
+    static int[][] display = {{1, 1, 1, 0, 1, 1, 1}, //0
+                            {0, 0, 1, 0, 0, 0, 1}, //1
+                            {0, 1, 1, 1, 1, 1, 0}, //2
+                            {0, 1, 1, 1, 0, 1, 1}, //3
+                            {1, 0, 1, 1, 0, 0, 1}, //4
+                            {1, 1, 0, 1, 0, 1, 1}, //5
+                            {1, 1, 0, 1, 1, 1, 1}, //6
+                            {0, 1, 1, 0, 0, 0, 1}, //7
+                            {1, 1, 1, 1, 1, 1, 1}, //8
+                            {1, 1, 1, 1, 0, 1, 1}}; //9
+    static long count = 0;
+ 
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+ 
+        //입력
+        String s = bf.readLine();
+        StringTokenizer st = new StringTokenizer(s);
+        
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        p = Integer.parseInt(st.nextToken());
+        x = Integer.parseInt(st.nextToken());
+        //입력 끝
+ 
+        int[] x_digit = num_to_digit(x);
+        check(0, x_digit);
+        System.out.println(count);
+    }
+ 
+    public static void check(int num, int[] x_digit) {
+        for(int i = 1; i <= n; i++) {
+            if(i == x) continue;
+            if(can_reverse(i, x_digit)) count++;
+        }
+    }
+ 
+    public static boolean can_reverse(int target, int[] x_digit) {
+        int[] target_digit = num_to_digit(target);
+ 
+        int diff_count = 0;
+        for(int i = 0; i < k; i++) {
+            for(int j = 0; j < 7; j++) {
+                if(display[x_digit[i]][j] != display[target_digit[i]][j]) {
+                    diff_count++;
+                    if(diff_count > p) return false;
+                }
+            }
+        }
+        return true;
+    }
+ 
+    public static int[] num_to_digit(int x) {
+        int[] result = new int[k];
+        for(int i = k - 1; i >= 0; i--) {
+            result[i] = x % 10;
+            x /= 10;
+        }
+        return result;
+    }
+}
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/22251
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
빌런 호석은 치르보기 빌딩의 엘리베이터 디스플레이의 LED 중에서 최소 
$1$개, 최대 
$P$개를 반전시킬 계획을 세우고 있다. 반전이란 켜진 부분은 끄고, 꺼진 부분은 켜는 것을 의미한다. 예를 들어 숫자 
$1$을 
$2$로 바꾸려면 총 5개의 LED를 반전시켜야 한다. 또한 반전 이후에 디스플레이에 올바른 수가 보여지면서 
$1$ 이상 
$N$ 이하가 되도록 바꿔서 사람들을 헷갈리게 할 예정이다. 치르보기를 사랑하는 모임의 회원인 당신은 호석 빌런의 행동을 미리 파악해서 혼쭐을 내주고자 한다. 현재 엘리베이터가 실제로는 
$X$층에 멈춰있을 때, 호석이가 반전시킬 LED를 고를 수 있는 경우의 수를 계산해보자.
## 🔍 풀이 방법
표시등에 대한 정보를 미리 입력해 둔다.
현재 층을 디스플레이 정보로 변환해 준다.
1 ~ N 중에 P개 이내의 표시등을 반전시켜 해당 수를 만들 수 있는지 확인한다.
## ⏳ 회고
SOSO
