### PR TITLE
[20250311]/BJ/골드1/13460/김민중

### DIFF
--- a/kmj-99/11 13460.md
+++ b/kmj-99/11 13460.md
@@ -1,0 +1,131 @@
+```java
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N,M = 0;
+    static int answer=101;
+    static boolean[][] visited;
+
+    static char[][] map;
+
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,1,-1};
+
+
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        map = new char[N][M];
+        // 구슬 map 구성
+        for(int i = 0; i < N; i++) {
+            String str = br.readLine();
+            for(int j = 0; j < M; j++) {
+                map[i][j] = str.charAt(j);
+            }
+        }
+
+        visited = new boolean[N][M];
+        int RX = 0;
+        int RY = 0;
+        int BX = 0;
+        int BY = 0;
+
+        for(int i=0; i<N; i++){
+            for(int j=0; j<M; j++){
+                if(map[i][j] == 'R') {
+                    map[i][j] = '.';
+                    RY = i;
+                    RX = j;
+                }
+
+                if(map[i][j] == 'B'){
+                    map[i][j] = '.';
+                    BY = i;
+                    BX = j;
+                }
+            }
+        }
+
+        for(int i = 0; i<4; i++){
+            dfs(RX, RY, BX, BY, i,0);
+        }
+
+
+        bw.write(answer+"");
+        bw.flush();
+        br.close();
+    }
+
+
+
+    public static void dfs(int rx, int ry, int bx, int by, int direct, int count){
+
+        int rrx = rx;
+        int rry = ry;
+
+        int bbx = bx;
+        int bby = by;
+
+        boolean isRedEnd = false;
+        boolean isBlueEnd = false;
+
+        while(true){
+            if(map[rry][rrx]=='0'){
+                // 성공
+                answer = Math.min(answer,count+1);
+                return;
+            }
+
+            if(map[bby][bbx]=='0'){
+               return;
+            }
+
+            if(!isRedEnd && map[rry][rrx]=='#'){
+                rrx -= dx[direct];
+                rry -= dy[direct];
+                isRedEnd = true;
+            }
+
+            if(!isBlueEnd && map[bby][bbx]=='#'){
+                bbx -= dx[direct];
+                bby -= dy[direct];
+                isBlueEnd = true;
+            }
+
+            if(isRedEnd && isBlueEnd){
+                break;
+            }
+
+            if(!isRedEnd){
+                rrx += dx[direct];
+                rry += dy[direct];
+            }
+
+            if(!isBlueEnd){
+                bbx += dx[direct];
+                bby += dy[direct];
+            }
+
+        }
+
+
+
+        for(int i = 0; i<4; i++){
+            dfs(rrx,rry,bbx,bby,i,count+1);
+        }
+
+
+    }
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13460
## 🧭 풀이 시간
200분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
스타트링크에서 판매하는 어린이용 장난감 중에서 가장 인기가 많은 제품은 구슬 탈출이다. 구슬 탈출은 직사각형 보드에 빨간 구슬과 파란 구슬을 하나씩 넣은 다음, 빨간 구슬을 구멍을 통해 빼내는 게임이다.

보드의 세로 크기는 N, 가로 크기는 M이고, 편의상 1×1크기의 칸으로 나누어져 있다. 가장 바깥 행과 열은 모두 막혀져 있고, 보드에는 구멍이 하나 있다. 빨간 구슬과 파란 구슬의 크기는 보드에서 1×1크기의 칸을 가득 채우는 사이즈이고, 각각 하나씩 들어가 있다. 게임의 목표는 빨간 구슬을 구멍을 통해서 빼내는 것이다. 이때, 파란 구슬이 구멍에 들어가면 안 된다.

이때, 구슬을 손으로 건드릴 수는 없고, 중력을 이용해서 이리 저리 굴려야 한다. 왼쪽으로 기울이기, 오른쪽으로 기울이기, 위쪽으로 기울이기, 아래쪽으로 기울이기와 같은 네 가지 동작이 가능하다.

각각의 동작에서 공은 동시에 움직인다. 빨간 구슬이 구멍에 빠지면 성공이지만, 파란 구슬이 구멍에 빠지면 실패이다. 빨간 구슬과 파란 구슬이 동시에 구멍에 빠져도 실패이다. 빨간 구슬과 파란 구슬은 동시에 같은 칸에 있을 수 없다. 또, 빨간 구슬과 파란 구슬의 크기는 한 칸을 모두 차지한다. 기울이는 동작을 그만하는 것은 더 이상 구슬이 움직이지 않을 때 까지이다.

보드의 상태가 주어졌을 때, 최소 몇 번 만에 빨간 구슬을 구멍을 통해 빼낼 수 있는지 구하는 프로그램을 작성하시오.
## 🔍 풀이 방법
빨간, 파란공이 '#'으로 이동한다고 가정을 하고, 빨간공이 '0'에 도착한다면 정답을 출력하는 식으로 접근했다. DFS로 맵을 돌면서, 최소 거리를 구하는 방식이다.
## ⏳ 회고
알고리즘은 어렵지 않은데, 구현이 좀 빡세서 내일 다시 해봐야겠다.
