### PR TITLE
[20250312] P5/BAJ/순환 순열/김득호

### DIFF
--- a/Ho/202503/12 순환순열.md
+++ b/Ho/202503/12 순환순열.md
@@ -1,0 +1,78 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Test {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        /*
+         최대 10만 자리라 2중 for문은 안된다.
+
+         문자열 A를 AA 형태로 붙여서 만든다.
+         이후 len(B) 만큼 인덱스르 0부터 len(A)까지 이동하면서 비교한다.
+
+         모두 일치하는 경우가 XOR 0이 나오는 경우임
+
+         */
+        String A = br.readLine();
+        String B = br.readLine();
+
+        int[] f = new int[B.length()]; //P랑 B 실패지점 관리
+
+        int j = 0;
+
+        for(int i = 1; i < B.length(); i++) {
+            while(j > 0 && B.charAt(i) != B.charAt(j)) {
+                //j번째까지 일치했다. f[j]에는 이전 길이가 j일때 접두=접미를 만드는 경우의 index 재활용하도록
+                j = f[j - 1];
+            }
+            if(B.charAt(i) == B.charAt(j)) {
+                j++;
+                f[i] = j;
+            }
+
+        }
+
+        String P = A + A;
+
+        int ans = 0;
+
+        j = 0;
+
+        for(int i = 0; i < P.length() - 1; i++) {
+            while(j > 0 && P.charAt(i) != B.charAt(j)) {
+                if(j == B.length() - 1) {
+                    j = f[j];
+                    continue;
+                }
+
+                j = f[j-1];
+            }
+
+            if(j == B.length() - 1) {
+                j = f[j];
+                ans++;
+            } else {
+                j++;
+            }
+        }
+
+        System.out.println(ans);
+    }
+}
+
+
+/*
+f배열은
+
+f[i] = 패턴 0부터 i번째 까지에서  접두/접미사의 길이가 같은 최대 길이
+그래서 틀리면
+
+j = f[j -1] 을 한다
+왜? 지금 j-1까지는 맞았는데 j가 틀렷으니까
+
+
+ */
+```


### PR DESCRIPTION
## 🧷 문제 링크

## 🧭 풀이 시간
분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
문자열 A,B 가 있고 B는 순환하는데 XOR 해서 0 이나오는 경우 구하기
## 🔍 풀이 방법
        /*
         최대 10만 자리라 2중 for문은 안된다.

         문자열 A를 AA 형태로 붙여서 만든다.
         이후 len(B) 만큼 인덱스르 0부터 len(A)까지 이동하면서 비교한다.

         모두 일치하는 경우가 XOR 0이 나오는 경우임

         */
## ⏳ 회고
KMP를 이해하고 정리하고 적용하고 해도 맨날 같은 부분에서 헷갈린다. 
f[] 배열은 0부터 i번째까지 접두/접미가 몇개 일치하는지  기록하는 배열이다.

만약 j랑 i 번 째가 다르면 
나는 j = f[j] 라고 했다 하지만 j = f[j - 1]을 해야한다.

무한루프를 도는 경우가 발생한다. 

왜일까?
일단 f[j]로 돌아간다는건 0부터 j 길이만큼 접두/접미가 몇개 일치하는지 기록되어있다.
이때 비교하는 문자가 처음부터 (i == 1, j == 0) 그리고 (i == 2, j == 1) 두 경우가 모두 일치하게 
증가한다면 무한루프를 발생시킨다.

EX) 
P = AAAB 일떄 
f =  {0, 1, 2, 0} 으로 만들어져야한다.
KMP 특성상 위 배열을 만들 때 

첫번째
A A A B
   A   
 위 처럼 비교해서 1을 채운다.
 
두번째

A A A B
   A A
이렇게 비교해서 2를 채운다.

세번째 
A  A  A B
    A  A  A

이렇게 되어서 불일치하게되는데 이때 i = 3이다
f[3]은 0부터 3번째 인덱스까지 선택한 문자열의 접두 접미 길이를 의미하는데
이 값을 구해가는 과정은 

3 - 1
A A A B
       A A
3 - 2
A A A B
          A

위 두과정을 거쳐서 일치하는게 없다는것을 확인하고 0이라는 값이 들어가야 한다.

자 그럼 j = f[j]인 경우에 내 코드는 
최초에 A A 두개가 일치한 상황이었기 때문에 최대길이 2라는 j값이 있다.
이때 최장길이 j랑 f[] 배열을 관리하는 index간에 1이라는 gap 발생하는데
이를 처리하지 않고 계속 같은 값과 비교하는 오류가 발생했다.

**그럼 j = f[j -1]의 값을 믿고 사용해도 되는걸까?**

결론부터하면 그래도 된다.
현재 j가 2였다는 것은 f[i -1]상황에서  j개의 접두사와 접미사가 일치했다는 것이 보장된다.
근데 현재 i번째 값 비교하는 시점에서 j (j = 2)와 일치하지 않는 상황이니까 
길이가 j인 0,1,2 이거는 길이가 3이다.

문자열로 축소해서 f[j -1] 배열 값을 확인하는 것이다.
이때 값이 있다면 길이 j에서 접두/접미가 일치하는 경우가 있으니까 
해당부분은 재활용해서 사용하겠다는 의미이다. 

이렇게 정리해도 다음에 또 까먹는다. 
계속하다보면 빨라지고 당연해지겟지요


