### PR TITLE
[20250313] BAJ / G3 / 소용돌이 이쁘게 출력하기 / 신희을

### DIFF
--- a/ShinHeeEul/202503/13 BAJ G3 소용돌이 이쁘게 출력하기.md
+++ b/ShinHeeEul/202503/13 BAJ G3 소용돌이 이쁘게 출력하기.md
@@ -1,0 +1,87 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    
+    static int[][] map;
+    public static void main(String[] args) throws Exception {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	
+    	
+    	int dir = 0;
+    	int[] di = {0, -1, 0, 1};
+    	int[] dj = {-1, 0, 1, 0};
+    	
+    	
+    	int i = 10000;
+    	int j = 10000;
+    	
+    	
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	
+    	int r1 = Integer.parseInt(st.nextToken()) + 5000;
+    	int c1 = Integer.parseInt(st.nextToken()) + 5000;
+    	int r2 = Integer.parseInt(st.nextToken()) + 5000;
+    	int c2 = Integer.parseInt(st.nextToken()) + 5000;
+    	
+    	map = new int[r2 - r1 + 1][c2 - c1 + 1];
+    	int cnt = 0;
+    	int limit = 10001;
+    	boolean bool = true;
+    	
+    	for(int a = 10001 * 10001 ; a > 0; a--) {
+    		
+    		if(i >= r1 && i <= r2 && j >= c1 && j <= c2) {
+    			map[i - r1][j - c1] = a;
+    		}
+    		cnt++;
+    		int nxti = i + di[dir];
+    		int nxtj = j + dj[dir];
+    		
+    		if(cnt == limit) {
+    			cnt = 0;
+    			if(bool) {
+    				bool = false;
+    				limit--;
+    			} else {
+    				bool = true;
+    			}
+    			dir = (dir + 1) % 4;
+    			i += di[dir];
+    			j += dj[dir];
+    			continue;
+    		}
+    		
+    		i = nxti;
+    		j = nxtj;
+    	}
+
+    	
+    	StringBuilder sb = new StringBuilder();
+    	int max = 0;
+    	for(int a = 0; a < map.length; a++) {
+    		for(int b = 0; b < map[0].length; b++) {
+    			max = Math.max(map[a][b], max);
+    		}
+    	}
+    	
+    	int ans = 0;
+    	while(max > 0) {
+    		ans ++;
+    		max /= 10;
+    	}
+    	
+    	for(int a = 0; a < map.length; a++) {
+    		for(int b = 0; b < map[0].length; b++) {
+    			sb.append(String.format("%" + ans + "d", map[a][b])).append(" ");
+    		}
+    		sb.append("\n");
+    	}
+    	
+    	System.out.println(sb);
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1022
## 🧭 풀이 시간
100 분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
크기가 무한인 정사각형 모눈종이가 있다. 모눈종이의 각 정사각형은 행과 열의 쌍으로 표현할 수 있다.

이 모눈종이 전체를 양의 정수의 소용돌이 모양으로 채울 것이다. 일단 숫자 1을 0행 0열에 쓴다. 그리고 나서 0행 1열에 숫자 2를 쓴다. 거기서 부터 소용돌이는 반시계 방향으로 시작된다. 다음 숫자는 다음과 같이 채우면 된다.

```
    -3 -2 -1  0  1  2  3
    --------------------
-3 |37 36 35 34 33 32 31
-2 |38 17 16 15 14 13 30
-1 |39 18  5  4  3 12 29
 0 |40 19  6  1  2 11 28
 1 |41 20  7  8  9 10 27
 2 |42 21 22 23 24 25 26
 3 |43 44 45 46 47 48 49
```
이 문제는 위와 같이 채운 것을 예쁘게 출력하면 된다. r1, c1, r2, c2가 입력으로 주어진다. r1, c1은 가장 왼쪽 위 칸이고, r2, c2는 가장 오른쪽 아래 칸이다.

예쁘게 출력한다는 것은 다음과 같이 출력하는 것이다.

출력은 r1행부터 r2행까지 차례대로 출력한다.
각 원소는 공백으로 구분한다.
모든 행은 같은 길이를 가져야 한다.
공백의 길이는 최소로 해야 한다.
모든 숫자의 길이(앞에 붙는 공백을 포함)는 같아야 한다.
만약 수의 길이가 가장 길이가 긴 수보다 작다면, 왼쪽에서부터 공백을 삽입해 길이를 맞춘다.

## 🔍 풀이 방법
소용돌이를 돌면서 범위 안에 들어온다면 정답 배열에 추가해준다. 이후 배열을 탐색하면서 최대 값을 구하고, %(최대값 자리수)d 형태로 출력한다.

## ⏳ 회고
그냥 다 배열에 때려박고 거기서 범위 잡아서 출력하려니까 메모리 초과 나더라. 메모리 초과도 신경쓰면서 하자