### PR TITLE
[20250320]/PGM/산모양타일링/LV3/김민중

### DIFF
--- a/kmj-99/202503/20 산모양타일링
+++ b/kmj-99/202503/20 산모양타일링
@@ -1,0 +1,32 @@
+```java
+
+public class Solution {
+    public int solution(int n, int[] tops) {
+        final int MOD = 10007;
+        int[] dp1 = new int[n];
+        int[] dp2 = new int[n];
+
+        dp1[0] = 1;
+        dp2[0] = 2 + tops[0];
+
+        for (int i = 1; i < n; i++) {
+            dp1[i] = (dp1[i - 1] + dp2[i - 1]) % MOD;
+            dp2[i] = ((dp1[i - 1] * (1 + tops[i])) + (dp2[i - 1] * (2 + tops[i]))) % MOD;
+        }
+
+        return (dp1[n - 1] + dp2[n - 1]) % MOD;
+    }
+
+    // 테스트용 메인 메서드
+    public static void main(String[] args) {
+        Solution sol = new Solution();
+        int n = 3;
+        int[] tops = {1, 0, 1};
+        System.out.println(sol.solution(n, tops)); // 예상 결과: 40
+    }
+}
+
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/258705?language=java
## 🧭 풀이 시간
200분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
사다리꼴의 윗변의 길이를 나타내는 정수 n과 사다리꼴 윗변에 붙인 정삼각형을 나타내는 1차원 정수 배열 tops가 매개변수로 주어집니다. 이때 문제 설명에 따라 만든 모양을 정삼각형 또는 마름모 타일로 빈 곳이 없도록 채우는 경우의 수를 10007로 나눈 나머지를 return 하도록 solution 함수를 완성해 주세요
## 🔍 풀이 방법
bfs,dfs로 풀경우 시간복잡도가 1000*1000*1000이 되므로 완전탐색으로 풀면 안된다. 그래서 dp를 통해 접근했다.  
## ⏳ 회고
문제 풀이를 이해하는 거 부터 쉽지 않았다. 다시 풀어봐야겠다.
