### PR TITLE
[20250321]/BJ/골드2/2169/김민중

### DIFF
--- a/kmj-99/202503/21 2169
+++ b/kmj-99/202503/21 2169
@@ -1,0 +1,71 @@
+```java
+
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, M;
+    static int[][] map;
+    static int[][] dp;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        dp = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dp[0][0] = map[0][0];
+        for(int i=1; i<M; i++){
+            dp[0][i] = dp[0][i-1] + map[0][i];
+        }
+
+        for(int i=1; i<N; i++){
+            int[] left_to_right = new int[M];
+            int[] right_to_left = new int[M];
+
+            for(int j=0; j<M; j++){
+                if(j==0){
+                    left_to_right[j] = dp[i-1][j] + map[i][j];
+                }else{
+                    left_to_right[j] = Math.max(left_to_right[j-1],dp[i-1][j]) + map[i][j];
+                }
+            }
+
+            for(int j=M-1; j>=0; j--){
+                if(j==M-1){
+                    right_to_left[j] = dp[i-1][j] + map[i][j];
+                }else{
+                    right_to_left[j] = Math.max(right_to_left[j+1],dp[i-1][j]) + map[i][j];
+                }
+            }
+
+            for(int j=0; j<M; j++){
+                dp[i][j] = Math.max(left_to_right[j],right_to_left[j]);
+            }
+        }
+
+        bw.write(dp[N-1][M-1]+"");
+        bw.flush();
+        bw.close();
+
+    }
+}
+
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2169
## 🧭 풀이 시간
200분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
NASA에서는 화성 탐사를 위해 화성에 무선 조종 로봇을 보냈다. 실제 화성의 모습은 굉장히 복잡하지만, 로봇의 메모리가 얼마 안 되기 때문에 지형을 N×M 배열로 단순화 하여 생각하기로 한다.

지형의 고저차의 특성상, 로봇은 움직일 때 배열에서 왼쪽, 오른쪽, 아래쪽으로 이동할 수 있지만, 위쪽으로는 이동할 수 없다. 또한 한 번 탐사한 지역(배열에서 하나의 칸)은 탐사하지 않기로 한다.

각각의 지역은 탐사 가치가 있는데, 로봇을 배열의 왼쪽 위 (1, 1)에서 출발시켜 오른쪽 아래 (N, M)으로 보내려고 한다. 이때, 위의 조건을 만족하면서, 탐사한 지역들의 가치의 합이 최대가 되도록 하는 프로그램을 작성하시오.
## 🔍 풀이 방법
완전 탐색으로 접근할 경우 시간초과가 나서, dp 로 접근해서 풀이
첫 번째 줄은 값을 도출할 수 있다는 것이 트리거이다.
## ⏳ 회고
dp 가 슬슬 익숙해 진다.