### PR TITLE
[20250331] BAJ/S2/분포표 만들기/김득호

### DIFF
--- a/Ho/202503/31 분포표만들기.md
+++ b/Ho/202503/31 분포표만들기.md
@@ -1,0 +1,35 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int m;
+    static int[] cnt;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        m = Integer.parseInt(br.readLine());
+        cnt = new int[m];
+
+        String line;
+        while ((line = br.readLine()) != null) {
+            StringTokenizer st = new StringTokenizer(line);
+            while(st.hasMoreTokens()) {
+                double s = Double.parseDouble(st.nextToken());
+                int idx = (int)(s * m + 1e-8);
+                if(idx >= m) idx = m - 1;
+                cnt[idx]++;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < cnt.length; i++) {
+            sb.append(cnt[i]).append(" ");
+        }
+        System.out.println(sb.toString().trim());
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14919
## 🧭 풀이 시간
40분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
0과 1사이의 실수 a1, a2, ..., aN이 입력으로 주어졌다고 하자.  구간 [0,1)을 다음과 같이 m개의 길이 L=1/m인 부분구간으로 나누자. 각 구간은 순서대로 b1, b2, ..., bm이다.

b1: 0 ≤ x < L,
b2: L ≤ x < 2L,
...
bm: (m-1)L ≤ x < 1.
입력된 실수중, 각 구간 b1, b2, ..., bm에 포함되는 수의 개수를 출력하시오.
## 🔍 풀이 방법
1/m 으로 나누어진 구간 중 어디에 해당하는 지 찾아야하는데 
이때 주어진 수에 m를 곱하고 (int)롤 변환해서 인덱스를 찾도록했다.
근데 부동 소수점 문제가 발생해서 문제가 틀렸다고 나왔고
아주작은 1e-8의 값을 더해주면 해결할 수 있다.
## ⏳ 회고
은근 부동소수점 이슈가 나중에 많이 생길텐데 알고 주의하자
