### PR TITLE
[20250429] BAJ / P1 / 바이러스 시뮬레이터 / 신희을

### DIFF
--- a/ShinHeeEul/202504/29 BAJ P1 바이러스 시뮬레이터.md
+++ b/ShinHeeEul/202504/29 BAJ P1 바이러스 시뮬레이터.md
@@ -1,0 +1,160 @@
+```java
+import java.io.FileInputStream;
+
+class Main {
+
+        static int N;
+        static int Q;
+        static Node[] segments;
+        static int size;
+        static long MIN = Long.MIN_VALUE / 80_000L;
+        static Node DEFAULT = new Node(MIN, MIN, MIN, 0, MIN, 50000000);
+
+        public static void main(String[] args) throws Exception {
+            System.setIn(new FileInputStream("54.in"));
+            N = read();
+            Q = read();
+            size = 1;
+
+            while(size < N) size <<= 1;
+
+            segments = new Node[(size << 1) + 1];
+
+
+            for(int i = size + 1; i < size + N + 1; i++) {
+                int a = read();
+                segments[i] = new Node(a, a, a, a, a, i - size);
+            }
+
+            for(int i = size + N + 1; i < segments.length; i++) segments[i] = DEFAULT;
+
+            int segmentSize = segments.length - 1;
+
+            while(segmentSize > 2) {
+                segments[segmentSize >> 1] = combine(segments[segmentSize - 1], segments[segmentSize]);
+                segmentSize -= 2;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            while(Q-->0) {
+                int a = read();
+                int b = read();
+                int c = read();
+
+    //            for(int i = 2; i < segments.length; i++) {
+    //                System.out.print(segments[i].max + " ");
+    //            }
+    //            System.out.println();
+                if(a == 1) {
+                    update(b, -c);
+                } else if(a == 2) {
+                    update(b, c);
+                } else {
+                    long d = query(b, c, 2, 1, size).max;
+                    sb.append(d < 0 ? 0 : d).append('\n');
+                }
+            }
+            System.out.write(sb.toString().getBytes());
+
+        }
+
+        public static void update(int index, long val) {
+            if(index > N) return;
+            index += size;
+            if(segments[index].largeIdx > 500000) return;
+            long a = (segments[index].max < 0 ? 0 : segments[index].max) + val;
+
+           if(a < 0) {
+               segments[index] = new Node(MIN,MIN,MIN,MIN,MIN, index - size);
+               int before = index;
+               index = (index + 1) >> 1;
+               while(index >= 2) {
+                   segments[index] = combine(segments[(index << 1) - 1], segments[index << 1]);
+                   index = (index + 1) >> 1;
+               }
+               update(queryLarge(before - size + 1, N, 2, 1,  size).largeIdx, a);
+           } else {
+               if(a == 0) a = MIN;
+               segments[index] = new Node(a, a, a, a, a, index - size);
+               index = (index + 1) >> 1;
+               while(index >= 2) {
+                   segments[index] = combine(segments[(index << 1) - 1], segments[index << 1]);
+                   index = (index + 1) >> 1;
+               }
+           }
+        }
+
+        public static Node queryLarge(int left, int right, int node, int start, int end) {
+            if(left > end || right < start) return DEFAULT;
+
+            if(left <= start && end <= right) {
+                return segments[node];
+            }
+
+            int mid = (start + end) >> 1;
+            Node ln = queryLarge(left, right, (node << 1) - 1, start, mid);
+            Node rn = queryLarge(left, right, node << 1, mid + 1, end);
+
+            if(ln.large >= rn.large) {
+                return ln;
+            } else {
+                return rn;
+            }
+        }
+
+        public static Node query(int left, int right, int node, int start, int end) {
+            if(left > end || right < start) return DEFAULT;
+
+            if(left <= start && end <= right) {
+                return segments[node];
+            }
+
+            int mid = (start + end) >> 1;
+            return combine(query(left, right, (node << 1) - 1, start, mid), query(left, right, node << 1, mid + 1, end));
+        }
+
+
+        public static Node combine(Node ln, Node rn) {
+
+            return new Node(
+                    Math.max(ln.lmax, ln.sum + rn.lmax),
+                    Math.max(rn.rmax, rn.sum + ln.rmax),
+                    Math.max(ln.rmax + rn.lmax, Math.max(ln.max, rn.max)),
+                    ln.sum + rn.sum,
+                    Math.max(ln.large, rn.large),
+                    ln.large >= rn.large ? ln.largeIdx : rn.largeIdx
+            );
+        }
+
+        static class Node {
+            long lmax;
+            long rmax;
+            long max;
+            long sum;
+            long large;
+            int largeIdx;
+
+            public Node(long lmax, long rmax, long max, long sum, long large, int largeIdx) {
+                this.lmax = lmax;
+                this.rmax = rmax;
+                this.max = max;
+                this.sum = sum;
+                this.large = large;
+                this.largeIdx = largeIdx;
+            }
+        }
+
+        private static int read() throws Exception {
+            int d, o;
+            d = System.in.read();
+
+
+            o = d & 15;
+            while ((d = System.in.read()) > 32)
+                o = (o << 3) + (o << 1) + (d & 15);
+
+            return o;
+        }
+
+    }
+```


### PR DESCRIPTION
## 🧷 문제 링크
## 🧭 풀이 시간
120+ 분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
2123년 봄, 드디어 '바이러스 시뮬레이터'가 출시되었다.

바이러스 시뮬레이터는 사람들의 면역력과 바이러스의 생명력 등을 설정하여 직접 시뮬레이션을 진행하는 프로그램으로, 훗날 바이러스가 창궐할 때를 대비하여 만든 프로그램이다.

이 시뮬레이터에는 초기에 $N$명의 사람들이 $1$번부터 $N$번까지 번호 순서대로 배치되어 있고, $i$번째 사람의 면역력은 $A_i$이다.

여기에 한 번 이상의 행동을 할 수 있으며, 행동의 종류는 바이러스 침투, 백신 접종, 그룹 면역력 측정 총 3가지가 있다. 각 행동은 입력으로 아래와 같이 주어진다.

 
$1$ $i$ $x$: 바이러스 침투 - 생명력이 $x$인 바이러스가 $i$번 사람에게 침투한다. 바이러스는 생명력을 $1$만큼 소모하여 감염자의 면역력을 $1$ 감소시킨다. 이때 침투한 바이러스가 죽기 전에 감염자의 면역력이 없거나(즉, 면역력이 $0$이거나) 없어지게 된다면, 바이러스는 현재 위치한 감염자의 번호보다 큰 번호를 가진 사람 중 가장 면역력이 높은 사람에게 전이되며, 생명력이 $0$이 되어 죽거나 더 이상 전이될 사람이 없을 때까지 반복된다. 전이 조건과 일치하는 사람이 여러 명일 경우, 그중 번호가 가장 작은 사람에게 전이된다. $(1 \le i \le N;1 \le x \le 10^{9})$ 
 
$2$ $i$ $x$: 백신 접종 - $i$번 사람에게 효력이 $x$인 백신을 접종하여 면역력이 $x$만큼 오른다. $(1 \le i \le N;1 \le x \le 10^{9})$ 
 
$3$ $l$ $r$: 그룹 면역력 측정 - $l$번부터 $r$번까지의 사람들이 그룹을 형성한다. 그룹은 인접한 사람들끼리 구성할 수 있고, 면역력이 없는 사람들은 없는 사람들끼리, 있는 사람들은 있는 사람들끼리 그룹을 만든다. 이때 구성되는 그룹 중, 그룹 구성원의 면역력의 합의 최댓값을 구한다. 
$(1 \le l \le r \le N)$ 
사람의 수 
$N$과 
$Q$번의 행동 목록이 주어지면, 시뮬레이터를 실행했을 때의 결과를 직접 출력해 보자.

행동은 행동 목록 순서대로 수행되며, 한 번의 행동이 완료될 때까지 그 다음 행동이 수행되지 않는다.
## 🔍 풀이 방법
금광 세그
## ⏳ 회고
MIN값의 범위를 깎아서 풀긴했지만, 잘못 푼 것 같다.