### PR TITLE
[20250507] BAJ / D5 / Strike Zone  / 신희을

### DIFF
--- a/ShinHeeEul/202505/07 BAJ D5 Strike Zone.md
+++ b/ShinHeeEul/202505/07 BAJ D5 Strike Zone.md
@@ -1,0 +1,158 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+class Main {
+
+
+    static int N;
+    static int size;
+    static Node[] segments;
+    static Point[] arr;
+    static long D_MIN = Long.MIN_VALUE >> 1;
+    static Node DEFAULT = new Node(D_MIN, D_MIN, D_MIN, 0);
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        ArrayList<Point> list = new ArrayList<>();
+
+        for(int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            list.add(new Point (Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken()), 1));
+        }
+
+        int M = Integer.parseInt(br.readLine());
+
+        for(int i = 0; i < M; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            list.add(new Point (Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken()), -1));
+        }
+
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int S = Integer.parseInt(st.nextToken());
+        int E = Integer.parseInt(st.nextToken());
+
+
+        arr = list.toArray(new Point[0]);
+
+        for(int i = 0; i < N; i++) arr[i].val *= S;
+        for(int i = N; i < N + M; i++) arr[i].val *= E;
+
+        N += M;
+
+        // x좌표가 작은 순으로 정렬
+        Arrays.sort(arr, (o1, o2) -> {
+            if(o1.x == o2.x) return o1.y - o2.y;
+            return o1.x - o2.x;
+        });
+
+
+        int cnt = 1;
+        for(int i = 0; i < N; i++) {
+            arr[i].index = cnt;
+            while(i != N - 1 && arr[i].x == arr[i + 1].x) {
+                arr[i + 1].index = cnt;
+                i++;
+            }
+            cnt++;
+        }
+
+        size = 1;
+
+        while(size < cnt) size <<= 1;
+
+        Arrays.sort(arr, Comparator.comparingInt(o -> o.y));
+
+
+        long max = 0;
+        for(int i = 0; i < N; i++) {
+
+            // y가 같으면 보지 않아야 됨
+            int start = i;
+            while(i != N-1 && arr[i].y == arr[i + 1].y) {
+                i++;
+            }
+
+            segments = new Node[(size << 1) + 1];
+            Arrays.fill(segments,DEFAULT);
+
+            for(int j = start; j < N; j++) {
+                update(arr[j].index, arr[j].val);
+                while(j != N - 1 && arr[j].y == arr[j + 1].y) {
+                    update(arr[j + 1].index, arr[j + 1].val);
+                    j++;
+                }
+                // 업데이트 치고 max 찾고
+                max = Math.max(max, segments[2].max);
+            }
+
+        }
+
+        System.out.println(max);
+    }
+
+    static void update(int index, long val) {
+        index += size;
+
+        if(segments[index] == DEFAULT) {
+            segments[index] = new Node(val, val, val, val);
+        } else {
+            segments[index].rmax += val;
+            segments[index].lmax += val;
+            segments[index].max += val;
+            segments[index].sum += val;
+        }
+
+        index = (index + 1) >> 1;
+        while(index >= 2) {
+            segments[index] = combine(segments[(index << 1) - 1], segments[index << 1]);
+            index = (index + 1) >> 1;
+        }
+    }
+
+    static Node combine(Node lNode, Node rNode) {
+        return new Node(
+                Math.max(lNode.lmax, lNode.sum + rNode.lmax),
+                Math.max(rNode.rmax, rNode.sum + lNode.rmax),
+                Math.max(lNode.rmax + rNode.lmax, Math.max(lNode.max, rNode.max)),
+                rNode.sum + lNode.sum
+        );
+    }
+
+    static class Node {
+        long rmax;
+        long lmax;
+        long max;
+        long sum;
+
+        public Node(long lmax, long rmax,long max, long sum) {
+            this.rmax = rmax;
+            this.lmax = lmax;
+            this.max = max;
+            this.sum = sum;
+        }
+    }
+
+    static class Point {
+        int x;
+        int y;
+        int val;
+        int index;
+
+        public Point(int x, int y, int val) {
+            this.x = x;
+            this.y = y;
+            this.val = val;
+        }
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17975
## 🧭 풀이 시간
120+ 분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
이 문제에서는 두 점 집합 P1(스트라이크)과 P2(볼), 그리고 상수 c1, c2가 주어집니다.
축에 평행한 직사각형 R을 정의할 때, eval(R) = c1 × s - c2 × b (R 안의 P1 점 개수는 보상, P2 점 개수는 벌점)를 최대화하는 R을 찾아야 합니다.
즉, 가능한 많은 스트라이크를 포함하고 가능한 적은 볼을 포함하는 최적의 스트라이크 존을 구하는 문제입니다.

## 🔍 풀이 방법
기본 금광 세그 문제다.
x좌표를 기준으로 정렬 후, 세그먼트 트리 리프 노드의 인덱스를 매긴다. (x좌표가 같다면 같은 인덱스를 부여한다)
다시 y좌표 기준으로 정렬 후,
바닥부터 꼭대기까지 올라가면서 update 한 후, 전 범위 연속합 최대를 구해주고
바닥을 제외한 y좌표부터 꼭대기까지 올라가면서 update 한 후, 전 범위 연속합 최대를 구해주고
다시 그 다음 y좌표부터 꼭대기까지 올라가면서 update 한 후, 전 범위 연속합 최대를 구해주고...
이 모든 값의 max를 구하면 정답!

(연속합 최대를 구할 때는 금광 세그먼트 트릭을 활용해 연속합을 구한다.)

## ⏳ 회고
비트 단위 입력으로 받으니 안되고, BufferedReader로 입력받으니까 통과되더라. 테스트 케이스에 탭이 섞여있나보다.