### PR TITLE
[20250508] BAJ / 골드3 / 욕심쟁이 판다 / 김민중

### DIFF
--- a/kmj-99/202505/1937.md
+++ b/kmj-99/202505/1937.md
@@ -1,0 +1,63 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int[][] map;
+    static int[][] dp;
+    static int N;
+    static int answer;
+
+    static int[] dy = {1,-1,0,0};
+    static int[] dx = {0,0,1,-1};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N= Integer.parseInt(st.nextToken());
+        map = new int[N][N];
+        dp = new int[N][N];
+
+        for(int i=0; i<N; i++){
+            StringTokenizer st2 = new StringTokenizer(br.readLine());
+            for(int j=0; j<N; j++){
+                map[i][j] = Integer.parseInt(st2.nextToken());
+            }
+        }
+
+        for(int i=0; i<N; i++){
+            for(int j=0; j<N; j++){
+                answer = Math.max(answer, dfs(j,i));
+            }
+        }
+
+        bw.write(answer+"");
+        bw.flush();
+        bw.close();
+    }
+
+
+    public static int dfs(int x, int y){
+        if(dp[y][x]!=0) return dp[y][x];
+
+        dp[y][x] = 1;
+
+        for(int i=0; i<4; i++){
+
+            int ny = y + dy[i];
+            int nx = x + dx[i];
+
+            if(ny<0 || ny>=N || nx<0 || nx>=N) continue;
+
+            if(map[y][x] < map[ny][nx]){
+                dp[y][x] = Math.max(dp[y][x], dfs(nx,ny) + 1);
+            }
+        }
+
+        return dp[y][x];
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1937
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
n × n의 크기의 대나무 숲이 있다. 욕심쟁이 판다는 어떤 지역에서 대나무를 먹기 시작한다. 그리고 그 곳의 대나무를 다 먹어 치우면 상, 하, 좌, 우 중 한 곳으로 이동을 한다. 그리고 또 그곳에서 대나무를 먹는다. 그런데 단 조건이 있다. 이 판다는 매우 욕심이 많아서 대나무를 먹고 자리를 옮기면 그 옮긴 지역에 그 전 지역보다 대나무가 많이 있어야 한다.

이 판다의 사육사는 이런 판다를 대나무 숲에 풀어 놓아야 하는데, 어떤 지점에 처음에 풀어 놓아야 하고, 어떤 곳으로 이동을 시켜야 판다가 최대한 많은 칸을 방문할 수 있는지 고민에 빠져 있다. 우리의 임무는 이 사육사를 도와주는 것이다. n × n 크기의 대나무 숲이 주어져 있을 때, 이 판다가 최대한 많은 칸을 이동하려면 어떤 경로를 통하여 움직여야 하는지 구하여라.
## 🔍 풀이 방법
dfs를 돌면서 dp 계산
## ⏳ 회고
좌표 다룰때 X,Y변수명 신경쓰자,,
