### PR TITLE
[20250623] BAJ/G2/트리의 지름/김득호

### DIFF
--- a/Ho/202506/23 트리의 지름.md
+++ b/Ho/202506/23 트리의 지름.md
@@ -1,0 +1,75 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+
+public class Main {
+    static int V;
+    static List<Edge>[] tree;
+    static boolean[] visited;
+    static int ans = 0;
+    static int leafIdx = 0;
+
+    static class Edge {
+        int to;
+        int cost;
+
+        public Edge(int to, int cost) {
+            this.to = to;
+            this.cost = cost;
+        }
+    }
+
+    // 13 : 32
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        V = Integer.parseInt(br.readLine());
+        tree = new ArrayList[V];
+
+        for (int i = 0; i < V; i++) {
+            tree[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < V; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken()) - 1;
+
+            while (true) {
+                int to = Integer.parseInt(st.nextToken());
+                if(to == - 1) break;
+
+                int cost = Integer.parseInt(st.nextToken());
+                tree[from].add(new Edge(to - 1, cost));
+            }
+        }
+
+        visited = new boolean[V];
+        dfs(0, 0);
+        visited = new boolean[V];
+        dfs(leafIdx, 0);
+        System.out.println(ans);
+    }
+    // 아무거나 잡아서 가장 깊은 곳 찾고 거기서부터 가장 먼곳 찾기
+
+
+    private static void dfs(int idx, int sum) {
+        visited[idx] = true;
+
+        if(sum > ans) {
+            ans = sum;
+            leafIdx = idx;
+        }
+
+        for(Edge e : tree[idx]) {
+            if(visited[e.to]) continue;
+            dfs(e.to, sum + e.cost);
+        }
+
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1167
## 🧭 풀이 시간
30분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
트리의 지름이란, 트리에서 임의의 두 점 사이의 거리 중 가장 긴 것을 말한다. 트리의 지름을 구하는 프로그램을 작성하시오.
## 🔍 풀이 방법
한 노드를 잡고 DFS를 이용해 가장 먼 노드를 찾는다.
해당 노드에서 DFS를 다시 실행해서 가장 먼 곳까지의 거리가 트리의 지름이다.
## ⏳ 회고
이전에 풀어서 알고있던 문제
