### PR TITLE
[20250625] BAJ/G5/흙길 보수하기/김득호

### DIFF
--- a/Ho/202506/25 흙길 보수하기.md
+++ b/Ho/202506/25 흙길 보수하기.md
@@ -1,0 +1,55 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static class Puddle {
+        int s, e;                // [s, e)  ← 끝점 exclusive
+
+        Puddle(int s, int e) {
+            this.s = s;
+            this.e = e;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int L = Integer.parseInt(st.nextToken());
+
+        PriorityQueue<Puddle> pq = new PriorityQueue<>(Comparator.comparingInt(p -> p.s));
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            pq.add(new Puddle(s, e));          // 그대로 저장 (len 안 씀)
+        }
+
+        int ans = 0;
+        int covered = 0;                       // 지금까지 덮인 구간의 오른쪽 끝 (exclusive)
+
+        while (!pq.isEmpty()) {
+            Puddle p = pq.poll();
+
+            // 이미 덮였으면 패스
+            if (covered >= p.e) continue;
+
+            // 안 덮인 부분의 시작점을 조정
+            if (covered < p.s) covered = p.s;
+
+            int remain = p.e - covered;                   // 남은 길이
+            int need   = (int) Math.ceil((double) remain / L);
+
+            ans     += need;
+            covered += need * L;                          // 새 널빤지만큼 오른쪽으로 이동
+        }
+
+        System.out.println(ans);
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1911
## 🧭 풀이 시간
40분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
어젯밤 겨울 캠프 장소에서 월드 본원까지 이어지는, 흙으로 된 비밀길 위에 폭우가 내려서 N(1 ≤ N ≤ 10,000)개의 물웅덩이가 생겼다. 월드학원은 물웅덩이를 덮을 수 있는 길이가 L(1 ≤ L ≤ 1,000,000)인 널빤지들을 충분히 가지고 있어서, 이들로 다리를 만들어 물웅덩이들을 모두 덮으려고 한다. 물웅덩이들의 위치와 크기에 대한 정보가 주어질 때, 모든 물웅덩이들을 덮기 위해 필요한 널빤지들의 최소 개수를 구하여라.

## 🔍 풀이 방법
가장 가까운 웅덩이부터 널판지를  배치하는 그리디 문제

## ⏳ 회고
코드를 더 쉽게 작성할 수 있도록 해보자
