### PR TITLE
[20250627] BAJ/G4/카드 정렬하기/김득호

### DIFF
--- a/Ho/202506/25 흙길 보수하기.md
+++ b/Ho/202506/25 흙길 보수하기.md
@@ -1,55 +1,70 @@
 ```java
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
 
 public class Main {
 
-    static class Puddle {
-        int s, e;                // [s, e)  ← 끝점 exclusive
+    static int N, L;
+    static class Node {
+        int start;
+        int end;
 
-        Puddle(int s, int e) {
-            this.s = s;
-            this.e = e;
+        public Node(int start, int end) {
+            this.start = start;
+            this.end = end;
         }
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
 
-        int N = Integer.parseInt(st.nextToken());
-        int L = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
 
-        PriorityQueue<Puddle> pq = new PriorityQueue<>(Comparator.comparingInt(p -> p.s));
+        int ans = 0;
+        int lastIdx = -1;
+
+        // 가장 왼쪽에 있는 웅덩이부터 널판지를 사용한다.
+        // 널판지가 붙어있는 마지막 위치를 기록한다.
+        // 다음 웅덩이 위치를 보고 널판지보다 작으면 그만큼 마이너스하고 새로운 널판지를 붙인다.
+
+        PriorityQueue<Node> pq = new PriorityQueue<>((n1, n2) -> Integer.compare(n1.start,n2.start));
 
         for (int i = 0; i < N; i++) {
             st = new StringTokenizer(br.readLine());
-            int s = Integer.parseInt(st.nextToken());
-            int e = Integer.parseInt(st.nextToken());
-            pq.add(new Puddle(s, e));          // 그대로 저장 (len 안 씀)
+
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+
+            pq.add(new Node(start, end));
         }
 
-        int ans = 0;
-        int covered = 0;                       // 지금까지 덮인 구간의 오른쪽 끝 (exclusive)
-
+        // 널판지 사용하기
         while (!pq.isEmpty()) {
-            Puddle p = pq.poll();
+            Node n = pq.poll();
 
-            // 이미 덮였으면 패스
-            if (covered >= p.e) continue;
+            int cnt = 0;
+            int start = n.start;
+            int end = n.end;
 
-            // 안 덮인 부분의 시작점을 조정
-            if (covered < p.s) covered = p.s;
+            //이전에 사용한 널판지가 웅덩이를 덮은 경우
+            if(lastIdx >= end) continue;
 
-            int remain = p.e - covered;                   // 남은 길이
-            int need   = (int) Math.ceil((double) remain / L);
+            if(lastIdx >= start) {
+                start += lastIdx - start + 1;
+            }
+            // 사용하는 널판지 개수 계산
+            cnt = (int) Math.ceil((double)(end - start)/L);
+            lastIdx = start + cnt * L;
+            ans +=cnt;
 
-            ans     += need;
-            covered += need * L;                          // 새 널빤지만큼 오른쪽으로 이동
         }
 
         System.out.println(ans);
     }
 }
-
 ```

--- a/Ho/202506/27 카드 정렬하기.md
+++ b/Ho/202506/27 카드 정렬하기.md
@@ -1,0 +1,51 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+
+public class Main {
+    // 13:30
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Long> pq = new PriorityQueue<>();
+
+        for (int i = 0; i < N; i++) {
+            Long num = Long.parseLong(br.readLine());
+            pq.add(num);
+        }
+
+        long ans = 0;
+        if(N == 1) {
+            System.out.println(0);
+        }
+        else{
+            while(!pq.isEmpty())  {
+                Long num1 = pq.poll();
+
+                if(pq.isEmpty())  {
+                    ans += num1;
+                    break;
+                }
+
+                Long num2 = pq.poll();
+
+                Long sum = num1 + num2;
+                ans += sum;
+                if(pq.isEmpty())  {
+                    break;
+                }
+                pq.add(sum);
+            }
+            System.out.println(ans);
+
+        }
+
+    }
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1715
## 🧭 풀이 시간
20분
## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하
## ✏️ 문제 설명
정렬된 두 묶음의 숫자 카드가 있다고 하자. 각 묶음의 카드의 수를 A, B라 하면 보통 두 묶음을 합쳐서 하나로 만드는 데에는 A+B 번의 비교를 해야 한다. 이를테면, 20장의 숫자 카드 묶음과 30장의 숫자 카드 묶음을 합치려면 50번의 비교가 필요하다.

매우 많은 숫자 카드 묶음이 책상 위에 놓여 있다. 이들을 두 묶음씩 골라 서로 합쳐나간다면, 고르는 순서에 따라서 비교 횟수가 매우 달라진다. 예를 들어 10장, 20장, 40장의 묶음이 있다면 10장과 20장을 합친 뒤, 합친 30장 묶음과 40장을 합친다면 (10 + 20) + (30 + 40) = 100번의 비교가 필요하다. 그러나 10장과 40장을 합친 뒤, 합친 50장 묶음과 20장을 합친다면 (10 + 40) + (50 + 20) = 120 번의 비교가 필요하므로 덜 효율적인 방법이다.

N개의 숫자 카드 묶음의 각각의 크기가 주어질 때, 최소한 몇 번의 비교가 필요한지를 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
우선 순위큐를 사용해서 작은 단위부터 비교한다.

## ⏳ 회고
