### PR TITLE
[20250702] BAJ / 골드4 / 타일채우기 / 김민중

### DIFF
--- a/kmj-99/202507/2 2133.md
+++ b/kmj-99/202507/2 2133.md
@@ -1,0 +1,37 @@
+```kotlin
+package com.prototype.codingtest.DP
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+fun main() {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+    val n = br.readLine().toInt()
+    if (n % 2 != 0) {
+        bw.write("0")
+        bw.flush()
+        return
+    }
+
+    val dp = MutableList(n + 1) { 0 }
+
+    // Base cases
+    dp[0] = 1 // 1 way to fill a 3x0 wall (do nothing)
+    dp[2] = 3 // 3 ways to fill a 3x2 wall
+
+    for (i in 4..n step 2) {
+        dp[i] = dp[i - 2] * 3
+        for (j in 4..i step 2) {
+            dp[i] += dp[i - j] * 2
+        }
+    }
+
+    bw.write("${dp[n]}")
+    bw.flush()
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2133
## 🧭 풀이 시간
60분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
3×N 크기의 벽을 2×1, 1×2 크기의 타일로 채우는 경우의 수를 구해보자.
## 🔍 풀이 방법
DP를 통해 (n-2)*3, (n-2)*2라는 점화식을 세워서 풀이
## ⏳ 회고
SOSO
