### PR TITLE
[20250702] SEA/PRO/물류창고/김득호

### DIFF
--- a/Ho/202507/2 물류창고.md
+++ b/Ho/202507/2 물류창고.md
@@ -1,0 +1,90 @@
+```java
+// Main.java
+package disContainer;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+class Main {
+	private final static int CMD_INIT 	= 1;
+	private final static int CMD_ADD 	= 2;
+	private final static int CMD_COST 	= 3;
+	private final static int MAX_N 		= 1400; 
+
+	private final static UserSolution usersolution = new UserSolution();
+	
+	private static boolean run(BufferedReader br) throws Exception {
+		StringTokenizer st;
+		int Q; 
+		int N;
+		int[] sCityArr = new int[MAX_N];
+		int[] eCityArr = new int[MAX_N];
+		int[] mCostArr = new int[MAX_N];
+		int sCity, eCity, mCost, mHub;
+		int cmd, ans, userAns; 
+		boolean isCorrect = false; 
+		
+		st = new StringTokenizer(br.readLine());
+		Q = Integer.parseInt(st.nextToken());
+		
+		for (int q = 0; q <Q; ++q) {
+			st = new StringTokenizer(br.readLine());
+			cmd = Integer.parseInt(st.nextToken());
+			
+			switch(cmd) {
+				case CMD_INIT:
+					isCorrect = true;
+					N = Integer.parseInt(st.nextToken());
+					for(int i = 0; i < N; i++) {
+						st = new StringTokenizer(br.readLine());
+						sCityArr[i] = Integer.parseInt(st.nextToken());
+						eCityArr[i] = Integer.parseInt(st.nextToken());
+						mCostArr[i] = Integer.parseInt(st.nextToken());
+					}
+					st = new StringTokenizer(br.readLine());
+					ans = Integer.parseInt(st.nextToken());
+					userAns = usersolution.init(N, sCityArr, eCityArr, mCostArr);
+					if(userAns != ans)
+						isCorrect = false; 	
+					break;
+				case CMD_ADD:
+					sCity = Integer.parseInt(st.nextToken());
+					eCity = Integer.parseInt(st.nextToken());
+					mCost= Integer.parseInt(st.nextToken());
+					usersolution.add(sCity, eCity, mCost);
+					break;
+				case CMD_COST:
+					mHub = Integer.parseInt(st.nextToken());
+					ans = Integer.parseInt(st.nextToken());
+					userAns = usersolution.cost(mHub);
+					if(userAns != ans)
+						isCorrect = false; 
+					break;
+				default:
+					isCorrect = false;
+					break;
+			}
+		}
+		return isCorrect;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		int TC, MARK;
+	
+		System.setIn(new java.io.FileInputStream("/Users/ho/IdeaProjects/Algorithm/B_Algo/src/disContainer/물류창고_testcase/1.in"));
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		TC = Integer.parseInt(st.nextToken());
+		MARK = Integer.parseInt(st.nextToken());
+
+		for (int testcase = 1; testcase <= TC; ++testcase) {
+			int score = run(br) ? MARK : 0;
+            System.out.println("#" + testcase + " " + score);
+		}
+		br.close();
+	}
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
## 🧭 풀이 시간
80분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
물류 운송에 필요한 최소시간 구하기

## 🔍 풀이 방법
주어지는 간선과 물류창고르 다익스트라를 이용해서 푼다.
이 때 주어지는 간선을 역방향으로 설계하면 모든 정점이 허브로 접근하는 
최소 시간을 구할 수 있기 때문에 이를 적용해야 최적의 시간을 구할 수 있다.

## ⏳ 회고
같은 유형을 자주 풀어보고 빠르게 설계하고 풀이하기
해설 강의을 들었기 때문에 다시 풀어보기