### PR TITLE
[20250702] BAJ / G4 / 카드 정렬하기 / 신희을

### DIFF
--- a/ShinHeeEul/202507/02 BAJ G4 카드 정렬하기.md
+++ b/ShinHeeEul/202507/02 BAJ G4 카드 정렬하기.md
@@ -1,0 +1,47 @@
+```java
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+public class Main
+{
+
+    public static void main(String[] args) throws Exception {
+        int N = read();
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        for(int i = 0; i < N; i++) pq.add(read());
+
+        if(N == 1) {
+            System.out.println(0);
+            return;
+        }
+        int sum = 0;
+        while(pq.size() > 1) {
+            int a = pq.poll();
+            int b = pq.poll();
+            sum += (a + b);
+            pq.add(a + b);
+        }
+        System.out.println(sum);
+    }
+
+    private static int read() throws Exception {
+        int d, o;
+        boolean negative = false;
+        d = System.in.read();
+
+        if (d == '-') {
+
+            negative = true;
+            d = System.in.read();
+        }
+        o = d & 15;
+        while ((d = System.in.read()) > 32)
+            o = (o << 3) + (o << 1) + (d & 15);
+
+        return negative? -o:o;
+    }
+
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1715
## 🧭 풀이 시간
30 분
## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하
## ✏️ 문제 설명
정렬된 두 묶음의 숫자 카드가 있다고 하자. 각 묶음의 카드의 수를 A, B라 하면 보통 두 묶음을 합쳐서 하나로 만드는 데에는 A+B 번의 비교를 해야 한다. 이를테면, 20장의 숫자 카드 묶음과 30장의 숫자 카드 묶음을 합치려면 50번의 비교가 필요하다.

매우 많은 숫자 카드 묶음이 책상 위에 놓여 있다. 이들을 두 묶음씩 골라 서로 합쳐나간다면, 고르는 순서에 따라서 비교 횟수가 매우 달라진다. 예를 들어 10장, 20장, 40장의 묶음이 있다면 10장과 20장을 합친 뒤, 합친 30장 묶음과 40장을 합친다면 (10 + 20) + (30 + 40) = 100번의 비교가 필요하다. 그러나 10장과 40장을 합친 뒤, 합친 50장 묶음과 20장을 합친다면 (10 + 40) + (50 + 20) = 120 번의 비교가 필요하므로 덜 효율적인 방법이다.

N개의 숫자 카드 묶음의 각각의 크기가 주어질 때, 최소한 몇 번의 비교가 필요한지를 구하는 프로그램을 작성하시오.
## 🔍 풀이 방법
그리디 + pq
## ⏳ 회고
N == 1일때 주의하자
