### PR TITLE
[20250707] BAJ / 골드2 / 색종이 붙이기 / 김민중

### DIFF
--- a/kmj-99/202507/7 17136
+++ b/kmj-99/202507/7 17136
@@ -1,0 +1,108 @@
+```java
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int[][] map;
+    static int answer = Integer.MAX_VALUE;
+    static int[] use = new int[5];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        Arrays.fill(use, 0);
+
+        map = new int[10][10];
+        for(int i=0; i<10; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j=0; j<10; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        dfs(0,0);
+        if(answer == Integer.MAX_VALUE){
+            bw.write("-1");
+        }else{
+            bw.write(answer+"");
+        }
+        bw.flush();
+        bw.close();
+    }
+
+    public static void dfs(int depth, int count){
+        if(depth == 100){
+            if(isCover()){
+                answer = Math.min(answer, count);
+            }
+            return;
+        }
+
+        int x = depth/10;
+        int y = depth%10;
+
+        if(map[x][y] == 0){
+            dfs(depth+1,count);
+            return;
+        }
+
+        boolean isRight = false;
+
+        for(int i=0; i<5; i++){
+
+            if(x+i>=10 || y+i>=10) break;
+            if(use[i]>=5 || !isValid(x,y,i)) continue;
+            isRight = true;
+
+            cover(x,y,i);
+            use[i] +=1;
+            dfs(depth+1, count+1);
+            use[i] -=1;
+            uncover(x,y, i);
+        }
+
+        if(!isRight) dfs(depth+1, count);
+
+    }
+
+    public static void cover(int x, int y, int size){
+        for(int i=x; i<=x+size; i++){
+            for(int j=y; j<=y+size; j++){
+                map[i][j] = 0;
+            }
+        }
+    }
+
+    public static void uncover(int x, int y, int size){
+        for(int i=x; i<=x+size; i++){
+            for(int j=y; j<=y+size; j++){
+                map[i][j] = 1;
+            }
+        }
+    }
+
+    public static boolean isValid(int x, int y, int size){
+        for(int i=x; i<=x+size; i++){
+            for(int j=y; j<=y+size; j++){
+                if(map[i][j] == 0) return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isCover(){
+        for(int i=0; i<10; i++){
+            for(int j=0; j<10; j++){
+                if(map[i][j] == 1) return false;
+            }
+        }
+
+        return true;
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17136
## 🧭 풀이 시간
120분
## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하
## ✏️ 문제 설명
<그림 1>과 같이 정사각형 모양을 한 다섯 종류의 색종이가 있다. 색종이의 크기는 1×1, 2×2, 3×3, 4×4, 5×5로 총 다섯 종류가 있으며, 각 종류의 색종이는 5개씩 가지고 있다.



<그림 1>

색종이를 크기가 10×10인 종이 위에 붙이려고 한다. 종이는 1×1 크기의 칸으로 나누어져 있으며, 각각의 칸에는 0 또는 1이 적혀 있다. 1이 적힌 칸은 모두 색종이로 덮여져야 한다. 색종이를 붙일 때는 종이의 경계 밖으로 나가서는 안되고, 겹쳐도 안 된다. 또, 칸의 경계와 일치하게 붙여야 한다. 0이 적힌 칸에는 색종이가 있으면 안 된다.

종이가 주어졌을 때, 1이 적힌 모든 칸을 붙이는데 필요한 색종이의 최소 개수를 구해보자.
## 🔍 풀이 방법
완전탐색을 돌리면서 색종이 별로 모든 경우의 수를 살펴봤다.
## ⏳ 회고
구현이 좀 까다롭다.
